### PR TITLE
Add credit loop to pollers

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
-          repository: cloudnull/directord/directord
+          repository: Directord/directord/directord
           tag_with_ref: true
 
   pypi_push_and_publish_pre:

--- a/components/job_wait.py
+++ b/components/job_wait.py
@@ -128,7 +128,8 @@ class Component(components.ComponentBase):
                     identity,
                 )
 
-            if driver.backend_check(interval=0.5):
+            if driver.backend_check(interval=0.5) and driver.credit > 0:
+                driver.credit -= 1
                 (
                     msg_id,
                     control,
@@ -221,6 +222,7 @@ class Component(components.ComponentBase):
                         control,
                         info,
                     )
+
             elif (
                 sorted(confirmed_identities) == sorted(job["identity"])
                 and all_identities_sent

--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -30,6 +30,7 @@ class BaseDriver:
     nullbyte = "\x00"  # Signals null
     transfer_start = "\x02"  # Signals transfer start
     transfer_end = "\x03"  # Signals transfer end
+    credit = 2048  # Driver connection credit loop
 
     def __init__(
         self,

--- a/directord/main.py
+++ b/directord/main.py
@@ -668,6 +668,7 @@ def main():
                         "HOST_UPTIME",
                         "AGENT_UPTIME",
                         "MACHINE_ID",
+                        "DRIVER",
                     ]
                 (
                     tabulated_data,

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -255,6 +255,7 @@ class TestDriverBase(unittest.TestCase):
         )
         self.mock_driver = self.mock_driver_patched.start()
         self.mock_driver.job_check.return_value = True
+        self.mock_driver.credit = 1
         self.mock_driver.nullbyte = base_driver.nullbyte
         self.mock_driver.heartbeat_notice = base_driver.heartbeat_notice
         self.mock_driver.job_ack = base_driver.job_ack

--- a/directord/tests/test_drivers_messaging.py
+++ b/directord/tests/test_drivers_messaging.py
@@ -51,13 +51,13 @@ class TestDriverMessaging(unittest.TestCase):
                 "host_uptime": 10,
                 "agent_uptime": 11,
                 "machine_id": "XXX123",
+                "driver": None,
             }
         )
         mock_send.assert_called()
         mock_send.assert_called_with(
             method="_heartbeat",
             topic="directord",
-            server="directord",
             identity=ANY,
             data=data,
         )
@@ -68,7 +68,6 @@ class TestDriverMessaging(unittest.TestCase):
         mock_send.assert_called_with(
             method="_heartbeat",
             topic="directord",
-            server="directord",
             identity=ANY,
             data=data,
         )


### PR DESCRIPTION
The credit loop will allow the server and client to run multiple
processes with realtime updates, without blocking or locking any
particular messaging function for prolonged periods of time.

* The ZMQ driver has also had the unlimited hwm setting remove
  now that the credit system has been implemented.

Signed-off-by: Kevin Carter <kecarter@redhat.com>