### PR TITLE
Migrate to directord organization

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 The only supported version is the most current
-[release](https://github.com/cloudnull/directord/releases). while it may
+[release](https://github.com/directord/directord/releases). while it may
 be possible to backport changes to previous releases, doing so is a labor
 of love.
 

--- a/contrib/container-build/directord.spec
+++ b/contrib/container-build/directord.spec
@@ -6,7 +6,7 @@ Release:        1%{?dist}
 Summary:        A deployment framework built to manage the data center life cycle
 
 License:        None
-URL:            https://github.com/cloudnull/directord
+URL:            https://github.com/directord/directord
 Version:        %{released_version}
 Source0:        directord.tar.gz
 BuildArch:      noarch

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -14,7 +14,7 @@ run 1000 tasks across a small 6 node environment.
 
 he following sections detail what was tested and how. All of the tools used for
 these tests are provided within the Directord
-[repository](https://github.com/cloudnull/directord).
+[repository](https://github.com/directord/directord).
 
 The server used (orchestration node) within the test environment was a
 standalone machine, which was not part of the test executions. The server only

--- a/docs/components.md
+++ b/docs/components.md
@@ -202,7 +202,7 @@ Directord cluster.
   needed on the client side to manage pods; `pip install directord[dev]`.
 
 > Client side **podman** needs to be setup to enable the socket API. The
-  orchestration [podman.yaml](https://github.com/cloudnull/directord/blob/main/orchestrations/podman.yaml)
+  orchestration [podman.yaml](https://github.com/directord/directord/blob/main/orchestrations/podman.yaml)
   can be used to automate the **podman** installation and setup process.
 
 ##### `SECONTEXT`
@@ -314,7 +314,7 @@ simple.
 #### Complete User Defined Component Example
 
 An example user defined component is available within the **components**
-directory of Directord; [echo component](https://github.com/cloudnull/directord/blob/main/components/echo.py).
+directory of Directord; [echo component](https://github.com/directord/directord/blob/main/components/echo.py).
 
 ##### Minified Example
 
@@ -357,7 +357,7 @@ orchestrations.
 
 > The following shell output is from the invocation of the above user-defined
   component, which can also be seen
-  [here](https://github.com/cloudnull/directord/blob/main/components/echo.py).
+  [here](https://github.com/directord/directord/blob/main/components/echo.py).
 
 
 ###### Help Information From Components
@@ -435,7 +435,7 @@ The `ComponentBase` offers an Ansible documentation to Directord argument
 conversion method `options_converter`, which will allow developers to create
 new Directord components with ease. An example of a converted module can be
 seen in the `container_config_data` component and found
-[here](https://github.com/cloudnull/directord/blob/main/components/container_config_data.py).
+[here](https://github.com/directord/directord/blob/main/components/container_config_data.py).
 
 #### Job specification
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -188,7 +188,7 @@ given checkout into the virtual environment.
 
 ``` shell
 python3 -m venv --system-site-packages /opt/directord
-/opt/directord/bin/pip install git+https://github.com/cloudnull/directord
+/opt/directord/bin/pip install git+https://github.com/directord/directord
 ```
 
 > Once Installed further installation customizations can be made within the

--- a/tools/prod-setup.sh
+++ b/tools/prod-setup.sh
@@ -55,13 +55,13 @@ fi
 
 eval "${COMMAND} ${PACKAGES}"
 
-RELEASE="$(get_latest_release cloudnull/directord)"
+RELEASE="$(get_latest_release directord/directord)"
 
 if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]] || [[ ${ID} == "fedora" ]]; then
   mkdir -p ~/directord-RPMS
   pushd ~/directord-RPMS
     rm -f rpm-bundle.tar.gz
-    wget https://github.com/cloudnull/directord/releases/download/${RELEASE}/rpm-bundle.tar.gz
+    wget https://github.com/directord/directord/releases/download/${RELEASE}/rpm-bundle.tar.gz
     tar xf rpm-bundle.tar.gz
     RPMS=$(ls -1 *.rpm | egrep -v '(debug|src)')
     dnf -y install ${RPMS}


### PR DESCRIPTION
Now directod is maintained under the 'directod' organization. This
change updates the repositories mentioned in documentation as well as
the ones used in scripts.

Note that container image is still maintained under the original
organization.