### PR TITLE
Remove the diskcache dep

### DIFF
--- a/components/container_config_data.py
+++ b/components/container_config_data.py
@@ -128,7 +128,6 @@ class Component(components.ComponentBase):
                 key="configs",
                 value=configs,
                 value_update=False,
-                tag="component",
             )
         else:
             self.log.debug(

--- a/contrib/container-build/Containerfile
+++ b/contrib/container-build/Containerfile
@@ -24,13 +24,11 @@ RUN dnf -y update && \
     chown -R builder /home/builder/build && \
     echo '%builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# TODO(cloudnull): remove all this when diskcache and ssh-python are packaged
+# TODO(cloudnull): remove all this when ssh-python is packaged
 RUN dnf -y install rpmdevtools python3-pytoml python3-pyxdg python38-requests cmake openssl openssl-devel python3-devel && \
     dnf -y groupinstall 'Development Tools' && \
     python3 -m venv /home/builder/pyp2rpm --system-site-packages && \
     /home/builder/pyp2rpm/bin/pip install pyp2rpm && \
-    /home/builder/pyp2rpm/bin/pyp2rpm --srpm diskcache -d /home/builder/rpm -b 3 && \
-    rpmbuild --rebuild "$(ls -1 /home/builder/rpm/python*-diskcache*.src.rpm)"  --nodeps --nocheck && \
     /home/builder/pyp2rpm/bin/pyp2rpm --srpm ssh-python -d /home/builder/rpm -b 3 && \
     rpmbuild --rebuild "$(ls -1 /home/builder/rpm/python*-ssh-python*.src.rpm)"  --nodeps --nocheck && \
     find ~/rpmbuild/RPMS -name '*.rpm' -exec cp "{}" /home/builder/build/ \; && \

--- a/contrib/container-build/directord.spec
+++ b/contrib/container-build/directord.spec
@@ -24,7 +24,6 @@ BuildRequires:  python3-oslo-messaging
 
 # Source Build Requirements
 # TODO(cloudnull): This needs to be packaged officially
-BuildRequires:  python3-diskcache
 BuildRequires:  python3-ssh-python
 
 %description
@@ -43,10 +42,6 @@ Requires:       python3-jinja2
 Requires:       python3-pyyaml
 Requires:       python3-tabulate
 Requires:       python3-tenacity
-
-# Source Requirements
-# TODO(cloudnull): This needs to be packaged officially
-Requires:       python3-diskcache
 
 # Recommends
 Recommends:       python3-ssh-python

--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -263,8 +263,6 @@ class ComponentBase:
         key,
         value,
         value_update=False,
-        expire=259200,
-        tag=None,
         extend=False,
     ):
         """Set a cached item.
@@ -278,10 +276,6 @@ class ComponentBase:
         :param value_update: Instructs the method to update a Dictionary with
                              another dictionary.
         :type value_update: Boolean
-        :param expire: Sets the expire time, defaults to 12 hours.
-        :type expire: Integer
-        :param tag: Sets the index for a given cached item.
-        :type tag: String
         :param extend: Enable|Disable Extend a map
         :type extend: Boolean
         :returns" Boolean
@@ -291,9 +285,9 @@ class ComponentBase:
             orig = cache.get(key, default=dict())
             value = utils.merge_dict(orig, value, extend=extend)
 
-        cache_set = cache.set(key, value, tag=tag, expire=expire, retry=True)
+        cache_set = cache.set(key, value)
         if not cache_set:
-            return cache.set(key, value, tag=tag, expire=expire, retry=True)
+            return cache.set(key, value)
         return cache_set
 
     def file_blueprinter(self, cache, file_to):

--- a/directord/components/builtin_arg.py
+++ b/directord/components/builtin_arg.py
@@ -122,7 +122,6 @@ class Component(components.ComponentBase):
                 key=cache_type,
                 value=cache_value,
                 value_update=True,
-                tag=cache_type,
                 extend=job.get("extend_args", False),
             )
             if cache_set:

--- a/directord/components/builtin_cachefile.py
+++ b/directord/components/builtin_cachefile.py
@@ -78,7 +78,6 @@ class Component(components.ComponentBase):
                 key="args",
                 value=cachefile_args,
                 value_update=True,
-                tag="args",
                 extend=True,
             )
             return "Cache file loaded", None, True, None

--- a/directord/server.py
+++ b/directord/server.py
@@ -58,13 +58,12 @@ class Server(interface.Interface):
                 self.log.debug("Disc base document store initialized")
                 path = os.path.abspath(os.path.expanduser(url.path))
                 # Ensure that the cache path exists before executing.
-                os.makedirs(path, exist_ok=True)
-                self.workers = disc.BaseDocument(
-                    url=os.path.join(path, "workers")
-                )
-                self.return_jobs = disc.BaseDocument(
-                    url=os.path.join(path, "jobs")
-                )
+                workers_path = os.path.join(path, "workers")
+                os.makedirs(workers_path, exist_ok=True)
+                self.workers = disc.BaseDocument(url=workers_path)
+                jobs_path = os.path.join(path, "jobs")
+                os.makedirs(jobs_path, exist_ok=True)
+                self.return_jobs = disc.BaseDocument(url=jobs_path)
             if url.scheme in ["redis", "rediss"]:
                 self.log.info("Connecting to redis datastore")
                 try:

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -164,21 +164,8 @@ class MockSocket:
 
 
 class FakeCache:
-    class transact:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def __enter__(self):
-            pass
-
-        def __exit__(self, *args, **kwargs):
-            pass
-
     def __init__(self):
         self.cache = {"args": {"test": 1}}
-
-    def iterkeys(self):
-        return list(self.cache.keys())
 
     def get(self, key, **kwargs):
         if key not in self.cache:
@@ -206,14 +193,17 @@ class FakeCache:
         self.cache = dict()
         return current
 
-    def volume(self):
-        return len(self.cache)
+    def sync(self):
+        pass
 
-    def check(self):
-        return [namedtuple("check", ["message"])("warning")]
+    def close(self):
+        pass
 
     def expire(self):
         pass
+
+    def items(self):
+        return list(self.cache.items())
 
     def __enter__(self):
         return self

--- a/directord/tests/test_client.py
+++ b/directord/tests/test_client.py
@@ -100,7 +100,7 @@ class TestClient(tests.TestDriverBase):
         with patch.object(self.mock_driver, "job_check", return_value=False):
             self.client.run_job(sentinel=True)
 
-    @patch("diskcache.Cache", autospec=True)
+    @patch("shelve.open", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_cache_check(
         self,
@@ -130,7 +130,7 @@ class TestClient(tests.TestDriverBase):
         with patch.object(self.mock_driver, "job_check", return_value=False):
             self.client.run_job(sentinel=True)
 
-    @patch("diskcache.Cache", autospec=True)
+    @patch("shelve.open", autospec=True)
     @patch("logging.Logger.info", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_skip_skip_cache_run(
@@ -164,7 +164,7 @@ class TestClient(tests.TestDriverBase):
             self.client.run_job(sentinel=True)
         mock_log_info.assert_called()
 
-    @patch("diskcache.Cache", autospec=True)
+    @patch("shelve.open", autospec=True)
     @patch("logging.Logger.info", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_skip_ignore_cache_run(
@@ -199,7 +199,7 @@ class TestClient(tests.TestDriverBase):
             self.client.run_job(sentinel=True)
         mock_log_info.assert_called()
 
-    @patch("diskcache.Cache", autospec=True)
+    @patch("shelve.open", autospec=True)
     @patch("logging.Logger.info", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_parent_failed_run(
@@ -233,7 +233,7 @@ class TestClient(tests.TestDriverBase):
             self.client.run_job(sentinel=True)
         mock_log_info.assert_called()
 
-    @patch("diskcache.Cache", autospec=True)
+    @patch("shelve.open", autospec=True)
     @patch("logging.Logger.info", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_cache_hit_run(
@@ -269,7 +269,7 @@ class TestClient(tests.TestDriverBase):
                 self.client.run_job(sentinel=True)
         mock_log_info.assert_called()
 
-    @patch("diskcache.Cache", autospec=True)
+    @patch("shelve.open", autospec=True)
     @patch("logging.Logger.info", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_run(
@@ -307,7 +307,7 @@ class TestClient(tests.TestDriverBase):
         mock_log_info.assert_called()
         self.assertEqual(cache.get("YYY"), self.mock_driver.job_end)
 
-    @patch("diskcache.Cache", autospec=True)
+    @patch("shelve.open", autospec=True)
     @patch("logging.Logger.info", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_run_outcome_false(
@@ -344,7 +344,7 @@ class TestClient(tests.TestDriverBase):
         self.assertEqual(cache.get("YYY"), self.mock_driver.job_failed)
 
     @patch("os.makedirs", autospec=True)
-    @patch("diskcache.Cache", autospec=True)
+    @patch("shelve.open", autospec=True)
     @patch("directord.client.Client.run_threads", autospec=True)
     def test_worker_run(self, mock_run_threads, mock_diskcache, mock_makedirs):
         self.client.worker_run()

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -126,8 +126,6 @@ class TestComponents(unittest.TestCase):
             cache=self.fake_cache,
             key="key1",
             value="value1",
-            expire=12345,
-            tag="test",
         )
 
     @patch("directord.utils.file_sha3_224", autospec=True)

--- a/directord/tests/test_datastore_disc.py
+++ b/directord/tests/test_datastore_disc.py
@@ -22,7 +22,7 @@ class TestDatastoreDisc(unittest.TestCase):
     def setUp(self):
         self.log_patched = patch("directord.logger.getLogger")
         self.log = self.log_patched.start()
-        self.diskcache_patched = patch("diskcache.Cache", autospec=True)
+        self.diskcache_patched = patch("shelve.open", autospec=True)
         self.diskcache_patched.start()
         self.datastore = datastore_disc.BaseDocument(url="file:///test/things")
 

--- a/directord/tests/test_drivers_zmq.py
+++ b/directord/tests/test_drivers_zmq.py
@@ -42,7 +42,6 @@ class TestDriverZMQSharedAuth(unittest.TestCase):
                     port=1234,
                 )
             self.assertEqual(bind.linger, -1)
-        mock_info_logging.assert_called()
 
     @patch("zmq.backend.Socket", autospec=True)
     @patch("zmq.Poller", autospec=True)
@@ -97,7 +96,6 @@ class TestDriverZMQ(unittest.TestCase):
         )
         self.assertIsNotNone(bind.bind)
         self.assertEqual(bind.plain_server, True)
-        mock_info_logging.assert_called()
 
     @patch("logging.Logger.info", autospec=True)
     def test_socket_connect_shared_key(self, mock_info_logging):
@@ -111,7 +109,6 @@ class TestDriverZMQ(unittest.TestCase):
         self.assertEqual(bind.plain_username, b"admin")
         self.assertEqual(bind.plain_password, b"test-key")
         self.assertEqual(bind.linger, -1)
-        mock_info_logging.assert_called()
 
     @patch("logging.Logger.info", autospec=True)
     def test_socket_connect(self, mock_info_logging):
@@ -121,7 +118,6 @@ class TestDriverZMQ(unittest.TestCase):
             port=1234,
         )
         self.assertEqual(bind.linger, -1)
-        mock_info_logging.assert_called()
 
     @patch("zmq.sugar.socket.Socket", autospec=True)
     def test_socket_send(self, mock_socket):
@@ -330,14 +326,12 @@ class TestDriverZMQ(unittest.TestCase):
     def test_job_connect(self, mock_log_debug, mock_socket_connect):
         self.driver._job_connect()
         mock_socket_connect.assert_called()
-        mock_log_debug.assert_called()
 
     @patch("directord.drivers.zmq.Driver._socket_connect", autospec=True)
     @patch("logging.Logger.debug", autospec=True)
     def test_backend_connect(self, mock_log_debug, mock_socket_connect):
         self.driver._backend_connect()
         mock_socket_connect.assert_called()
-        mock_log_debug.assert_called()
 
     def test_zmq_mode_client(self):
         client_args = tests.FakeArgs()

--- a/directord/tests/test_init.py
+++ b/directord/tests/test_init.py
@@ -199,7 +199,6 @@ class TestUnixSocket(unittest.TestCase):
             conn.side_effect = PermissionError()
             with self.assertRaises(PermissionError):
                 directord.send_data("/test.sock", "test")
-        mock_log_error.assert_called()
 
 
 class TestDirectordConnect(unittest.TestCase):

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -359,7 +359,6 @@ class TestServer(tests.TestDriverBase):
         with patch("builtins.open", m):
             self.server.run_backend(sentinel=True)
         self.mock_driver.backend_send.assert_called()
-        mock_log_info.assert_called()
 
     def test_create_return_jobs(self):
         self.server.return_jobs = datastores.BaseDocument()
@@ -660,7 +659,6 @@ class TestServer(tests.TestDriverBase):
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, True, False]
             self.server.run_interactions(sentinel=True)
-        mock_log_debug.assert_called()
         mock_set_job_status.assert_called_with(
             ANY,
             job_status=self.server.driver.transfer_end,

--- a/directord/tests/test_user.py
+++ b/directord/tests/test_user.py
@@ -252,7 +252,7 @@ class TestManager(tests.TestDriverBase):
         )
 
     @patch("builtins.print")
-    @patch("diskcache.Cache", autospec=True)
+    @patch("directord.utils.Cache", autospec=True)
     def test_run_override_dump_cache(self, mock_diskcache, mock_print):
         cache = mock_diskcache.return_value = tests.FakeCache()
         cache.set(key="test", value="value")
@@ -262,9 +262,7 @@ class TestManager(tests.TestDriverBase):
         )
 
     @patch("builtins.print")
-    @patch("diskcache.Cache", autospec=True)
+    @patch("shelve.open", autospec=True)
     def test_run_override_dump_cache_empty(self, mock_diskcache, mock_print):
-        cache = mock_diskcache.return_value = tests.FakeCache()
-        cache.clear()
         self.manage.run(override="dump-cache")
         mock_print.assert_called_with("{}")

--- a/directord/tests/test_utils.py
+++ b/directord/tests/test_utils.py
@@ -128,15 +128,7 @@ class TestUtils(tests.TestConnectionBase):
         with utils.SSHConnect(
             host="test", username="testuser", port=22, key_file="/test/key"
         ):
-            mock_log_debug.assert_called()
             mock_import_key.assert_called()
-
-    @patch("logging.Logger.debug", autospec=True)
-    def test_sshconnect_agent_default(self, mock_log_debug):
-        with patch("os.path.exists") as mock_path:
-            mock_path.return_value = True
-            with utils.SSHConnect(host="test", username="testuser", port=22):
-                mock_log_debug.assert_called()
 
     @patch("ssh.key.import_privkey_file", autospec=True)
     @patch("logging.Logger.debug", autospec=True)
@@ -153,8 +145,6 @@ class TestUtils(tests.TestConnectionBase):
                 mock_path.return_value = True
                 ssh.set_auth()
 
-        mock_log_debug.assert_called()
-        mock_log_warning.assert_called()
         mock_import_key.assert_called()
 
     def test_file_sha3_224(self):

--- a/directord/user.py
+++ b/directord/user.py
@@ -17,11 +17,10 @@ import json
 import os
 import time
 
-import diskcache
-
 import directord
 
 from directord import interface
+from directord import utils
 
 
 class User(interface.Interface):
@@ -340,15 +339,13 @@ class Manage(User):
         """
 
         def _cache_dump():
-            with diskcache.Cache(
-                self.args.cache_path,
-                tag_index=True,
-                disk=diskcache.JSONDisk,
-            ) as cache:
-                cache_dict = {}
-                for item in cache.iterkeys():
-                    cache_dict[item] = cache.get(item)
-                print(json.dumps(cache_dict, indent=4))
+            try:
+                with utils.Cache(
+                    path=self.args.cache_path, filename="client.db", flags="r"
+                ) as cache:
+                    print(json.dumps(dict(cache.items()), indent=4))
+            except KeyError:
+                pass
 
         execution_map = {
             "dump-cache": _cache_dump,

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setuptools.setup(
     zip_safe=False,
     test_suite="tests",
     install_requires=[
-        "diskcache",
         "jinja2",
         "pyyaml",
         "ssh-python",

--- a/tools/prod-setup.sh
+++ b/tools/prod-setup.sh
@@ -38,7 +38,7 @@ if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]]; then
   fi
   COMMAND="dnf -y install"
 elif [[ ${ID} == "fedora" ]]; then
-  PACKAGES="git wget python3 python3-ssh-python python3-tenacity python3-tabulate python3-zmq python3-pyyaml python3-jinja2 zeromq libsodium python3-diskcache"
+  PACKAGES="git wget python3 python3-ssh-python python3-tenacity python3-tabulate python3-zmq python3-pyyaml python3-jinja2 zeromq libsodium"
   if [ "${DRIVER}" == "messaging" ]; then
     PACKAGES+=" qpid-dispatch-router"
   fi


### PR DESCRIPTION
This change removes diskcache as a dependency from Directord. While the
diskcache lib is well maintained and works well for our usecase, the
library is an additional dependency which operators need not maintain or
worry about. This change converts our caching mechanism to a native
python shelve.

Signed-off-by: Kevin Carter <kecarter@redhat.com>