### PR TITLE
Add option to allow operators to set the machine id

### DIFF
--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -59,12 +59,16 @@ class BaseDriver:
         self.encrypted_traffic_data = encrypted_traffic_data
         self.log = logger.getLogger(name="directord")
         self.args = args
-        if args.identity:
-            self.identity = args.identity
-        else:
+
+        self.identity = getattr(args, "identity", socket.gethostname())
+        if not self.identity:
             self.identity = socket.gethostname()
+
+        self.machine_id = getattr(args, "machine_id", self.get_machine_id())
+        if not self.machine_id:
+            self.machine_id = self.get_machine_id()
+
         self.interface = interface
-        self.machine_id = self.get_machine_id()
 
     def __copy__(self):
         """Return a copy of the base class.

--- a/directord/interface.py
+++ b/directord/interface.py
@@ -58,8 +58,6 @@ class Interface(directord.Processor):
             self.public_keys_dir
         ) and os.path.exists(self.secret_keys_dir)
 
-        self.log.debug("Loading messaging driver")
-
         try:
             _driver = directord.plugin_import(
                 plugin=".drivers.{}".format(self.args.driver)
@@ -69,6 +67,7 @@ class Interface(directord.Processor):
                 "Driver was not able to be loaded: {}".format(str(e))
             )
         else:
+            self.log.info("Loading messaging driver: [ %s ]", self.args.driver)
             self.driver = _driver.Driver(
                 args=self.args,
                 encrypted_traffic_data={

--- a/directord/main.py
+++ b/directord/main.py
@@ -206,6 +206,13 @@ def _args(exec_args=None):
     )
     parser_server = subparsers.add_parser("server", help="Server mode help")
     parser_client = subparsers.add_parser("client", help="Client mode help")
+    parser_client.add_argument(
+        "--machine-id",
+        help="Set a machine id override",
+        metavar="STRING",
+        default=os.getenv("DIRECTORD_MACHINE_ID", None),
+        type=str,
+    )
     parser_orchestrate = subparsers.add_parser(
         "orchestrate", help="Orchestration mode help"
     )

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -142,6 +142,7 @@ class FakeArgs:
     messaging_ssl_ca = "/etc/pki/ca-trust/source/anchors/cm-local-ca.pem"
     messaging_ssl_cert = "/etc/directord/messaging/ssl/directord.crt"
     messaging_ssl_key = "/etc/directord/messaging/ssl/directord.key"
+    machine_id = None
 
 
 class MockSocket:

--- a/directord/tests/test_main.py
+++ b/directord/tests/test_main.py
@@ -362,6 +362,7 @@ class TestMain(unittest.TestCase):
                 "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
+                "machine_id": None,
                 "mode": "client",
                 "identity": None,
             },


### PR DESCRIPTION
This change allows operators to define the machine id. While the machine
id should be auto generated, when running in containerized infra, the ID
is passed through to the container, so to be able to run multiple
directord containers on a single host, we need the ability to define a
unique id.

Signed-off-by: Kevin Carter <kecarter@redhat.com>