### PR TITLE
Fix TLS verify for all podman code

### DIFF
--- a/components/container_image.py
+++ b/components/container_image.py
@@ -37,10 +37,10 @@ class Component(components.ComponentBase):
             help="Path to the podman socket. Default: %(default)s",
         )
         self.parser.add_argument(
-            "--tlsverify",
-            default=True,
-            type=bool,
-            help="Whether to use TLS verify for registry Default: %(default)s",
+            "--no-tlsverify",
+            default=False,
+            action="store_true",
+            help="Skip using TLS verify for registry Default: %(default)s",
         )
         action_group = self.parser.add_mutually_exclusive_group(required=True)
         action_group.add_argument(
@@ -90,6 +90,7 @@ class Component(components.ComponentBase):
         super().server(exec_array=exec_array, data=data, arg_vars=arg_vars)
         data["images"] = self.known_args.images
         data["socket_path"] = self.known_args.socket_path
+        data["tlsverify"] = not self.known_args.no_tlsverify
         if self.known_args.pull:
             data["action"] = "pull"
         elif self.known_args.push:

--- a/components/pod.py
+++ b/components/pod.py
@@ -56,9 +56,10 @@ class Component(components.ComponentBase):
             help="Access a container with privleges.",
         )
         self.parser.add_argument(
-            "--tls-verify",
+            "--no-tlsverify",
+            default=False,
             action="store_true",
-            help="Verify certificates when pulling container images.",
+            help="Skip using TLS verify for registry Default: %(default)s",
         )
         self.parser.add_argument(
             "--force",
@@ -138,7 +139,7 @@ class Component(components.ComponentBase):
             data["pod_action"] = "play"
             data["kwargs"] = dict(
                 pod_file=self.known_args.play,
-                tls_verify=self.known_args.tls_verify,
+                tlsverify=(not self.known_args.no_tlsverify),
             )
         elif self.known_args.exec_run:
             data["pod_action"] = "exec_run"

--- a/directord/components/lib/podman.py
+++ b/directord/components/lib/podman.py
@@ -157,11 +157,13 @@ class PodmanPod(PodmanConnect):
         resp = self.api.get(path="/pods/{name}/json".format(name=name))
         return resp.ok, self._decode(resp.content)
 
-    def play(self, pod_file, tls_verify=True):
+    def play(self, pod_file, tlsverify=True):
         """Instantiate a given pod and return the action status.
 
         :param pod_file: Full path to a pod YAML file.
         :type pod_file: String
+        :param tlsverify: Enable TLS verification
+        :type tlsverify: Boolean
         :returns: Tuple
         """
 
@@ -170,7 +172,7 @@ class PodmanPod(PodmanConnect):
                 resp = self.api.post(
                     path="/play/kube",
                     data=json.dumps(yaml.safe_load(f)),
-                    params={"tlsVerify": tls_verify, "start": True},
+                    params={"tlsVerify": tlsverify, "start": True},
                 )
             return resp.ok, self._decode(resp.content)
 
@@ -245,7 +247,7 @@ class PodmanImage(PodmanConnect):
 
         :param images: Image names to pull
         :type images: List
-        :param tlsverify: TLS verification
+        :param tlsverify: Enable TLS verification
         :type tlsverify: Boolean
         :returns: Tuple
         """
@@ -271,7 +273,7 @@ class PodmanImage(PodmanConnect):
 
         :param images: Image names to push
         :type images: List
-        :param tlsverify: TLS verification
+        :param tlsverify: Enable TLS verification
         :type tlsverify: Boolean
         :returns: Tuple
         """

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -966,7 +966,7 @@ class TestComponents(unittest.TestCase):
             },
             {
                 "mock": MagicMock(ok=False, content=None),
-                "kwargs": {"pod_file": "/path/to/file", "tls_verify": False},
+                "kwargs": {"pod_file": "/path/to/file", "tlsverify": False},
                 "post_dict": {
                     "path": "/play/kube",
                     "params": {"tlsVerify": False, "start": True},


### PR DESCRIPTION
It was impossible to set TLS verify to False, use `--no-tlsverify` option for that.
Use unified var name `tlsverify` through podman modules.