### PR TITLE
Connect to client to get hostname

### DIFF
--- a/tools/directord-dev-bootstrap-messaging-catalog.yaml
+++ b/tools/directord-dev-bootstrap-messaging-catalog.yaml
@@ -12,7 +12,7 @@ directord_server:
   - ADD: scripts/messaging/getcert.sh getcert.sh
   - RUN: |-
       {% for client in directord_clients['targets'] %}
-        hostname=$(ssh -i {{ directord_bootstrap['key_file']|default("~/.ssh/id_rsa") }} {{ directord_bootstrap['username'] }}@{{ directord_bootstrap['host'] }} hostname)
+        hostname=$(ssh -o StrictHostKeyChecking=no -i {{ directord_bootstrap['key_file']|default("~/.ssh/id_rsa") }} {{ directord_bootstrap['username'] }}@{{ client['host'] }} hostname)
         sudo ./getcert.sh {{ client['host'] }} /opt/directord/messaging-ssl ${hostname}
       {% endfor %}
   - RUN: |-


### PR DESCRIPTION
Connect to each client to get the hostname, not the node running the
directord bootstrap. Previously, this only worked when it was an all in
one node running the client and server. This change makes the messaging
bootstrap work across multiple client nodes.

Signed-off-by: James Slagle <jslagle@redhat.com>
