### PR TITLE
Job interaction improvements

### DIFF
--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -32,7 +32,6 @@ class BaseDriver:
     coordination_failed = "\x07"  # Signals coordination failed
     coordination_ack = "\x10"  # Signals coordination acknowledged
     coordination_notice = "\x11"  # Signals coordination notice
-    job_ack = "\x06"  # Signals job acknowledged
     job_end = "\x04"  # Signals job ended
     job_failed = "\x15"  # Signals job failed
     job_processing = "\x16"  # Signals job processing

--- a/directord/drivers/messaging.py
+++ b/directord/drivers/messaging.py
@@ -616,7 +616,7 @@ class Driver(drivers.BaseDriver):
         """
 
         job_id = utils.get_uuid()
-        self.log.debug(
+        self.log.info(
             "Job [ %s ] sending heartbeat from [ %s ] to server",
             job_id,
             self.identity,

--- a/directord/drivers/zmq.py
+++ b/directord/drivers/zmq.py
@@ -724,7 +724,7 @@ class Driver(drivers.BaseDriver):
         """
 
         job_id = utils.get_uuid()
-        self.log.debug(
+        self.log.info(
             "Job [ %s ] sending heartbeat from [ %s ] to server",
             job_id,
             self.identity,

--- a/directord/meta.py
+++ b/directord/meta.py
@@ -12,7 +12,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 __author__ = "Kevin Carter"
 __email__ = "kevin@cloudnull.com"
 __driver_default__ = "zmq"

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -256,7 +256,6 @@ class TestDriverBase(unittest.TestCase):
         self.mock_driver.credit = 1
         self.mock_driver.nullbyte = base_driver.nullbyte
         self.mock_driver.heartbeat_notice = base_driver.heartbeat_notice
-        self.mock_driver.job_ack = base_driver.job_ack
         self.mock_driver.job_end = base_driver.job_end
         self.mock_driver.job_processing = base_driver.job_processing
         self.mock_driver.job_failed = base_driver.job_failed

--- a/directord/tests/test_client.py
+++ b/directord/tests/test_client.py
@@ -131,7 +131,7 @@ class TestClient(tests.TestDriverBase):
             self.client.run_job(sentinel=True)
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.info", autospec=True)
+    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_skip_skip_cache_run(
         self,
@@ -165,7 +165,7 @@ class TestClient(tests.TestDriverBase):
         mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.info", autospec=True)
+    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_skip_ignore_cache_run(
         self,
@@ -200,7 +200,7 @@ class TestClient(tests.TestDriverBase):
         mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.info", autospec=True)
+    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_parent_failed_run(
         self,
@@ -234,7 +234,7 @@ class TestClient(tests.TestDriverBase):
         mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.info", autospec=True)
+    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_cache_hit_run(
         self,
@@ -270,7 +270,7 @@ class TestClient(tests.TestDriverBase):
         mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.info", autospec=True)
+    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_run(
         self,
@@ -308,7 +308,7 @@ class TestClient(tests.TestDriverBase):
         self.assertEqual(cache.get("YYY"), self.mock_driver.job_end)
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.info", autospec=True)
+    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_run_outcome_false(
         self,

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -47,11 +47,11 @@ class TestServer(tests.TestDriverBase):
                 "PARENT_JOB_ID": "ZZZ",
                 "_createtime": 1,
                 "_lasttime": ANY,
-                "_processing": {"test-node": "\x06"},
+                "_processing": {"test-node": "\x16"},
             }
         }
         self.server._set_job_status(
-            job_status=self.server.driver.job_ack,
+            job_status=self.server.driver.job_processing,
             job_id="XXX",
             identity="test-node",
             job_output="output",
@@ -65,14 +65,14 @@ class TestServer(tests.TestDriverBase):
                 "JOB_DEFINITION": {},
                 "_nodes": ["test-node"],
                 "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x04",
+                "PROCESSING": "\x16",
                 "STDERR": {},
                 "STDOUT": {},
                 "JOB_SHA3_224": "YYY",
                 "VERB": "RUN",
                 "_createtime": 1,
                 "_lasttime": ANY,
-                "_processing": {"test-node": "\x06"},
+                "_processing": {"test-node": "\x16"},
             },
         )
 
@@ -94,7 +94,7 @@ class TestServer(tests.TestDriverBase):
             }
         }
         self.server._set_job_status(
-            job_status=self.server.driver.job_ack,
+            job_status=self.server.driver.job_processing,
             job_id="XXX",
             identity="test-node",
             job_output="output",
@@ -109,14 +109,14 @@ class TestServer(tests.TestDriverBase):
                 "JOB_DEFINITION": {},
                 "_nodes": ["test-node"],
                 "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x04",
+                "PROCESSING": "\x16",
                 "STDERR": {},
                 "STDOUT": {"test-node": "stdout"},
                 "JOB_SHA3_224": "YYY",
                 "VERB": "RUN",
                 "_createtime": 1,
                 "_lasttime": ANY,
-                "_processing": {"test-node": "\x06"},
+                "_processing": {"test-node": "\x16"},
             },
         )
 
@@ -138,7 +138,7 @@ class TestServer(tests.TestDriverBase):
             }
         }
         self.server._set_job_status(
-            job_status=self.server.driver.job_ack,
+            job_status=self.server.driver.job_processing,
             job_id="XXX",
             identity="test-node",
             job_output="output",
@@ -153,14 +153,14 @@ class TestServer(tests.TestDriverBase):
                 "JOB_DEFINITION": {},
                 "_nodes": ["test-node"],
                 "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x04",
+                "PROCESSING": "\x16",
                 "STDERR": {"test-node": "stderr"},
                 "STDOUT": {},
                 "JOB_SHA3_224": "YYY",
                 "VERB": "RUN",
                 "_createtime": 1,
                 "_lasttime": ANY,
-                "_processing": {"test-node": "\x06"},
+                "_processing": {"test-node": "\x16"},
             },
         )
 


### PR DESCRIPTION
Server side job handling was all done within a consistent loop, this
change adds a quick handling check when sending so that the server is
always processing data, and never in an idle state when work is needed
to be done.

The credit process is no longer needed and removing it will improve
performance by about 5%. This change removes the credit functions
from the core client and server and improves some logging.

Meta rev to 0.11.2

JOB ACK was removed. The job ack control no longer has any purpose given
the use of the processing control. The job ack was an old interaction
which was kept for legacy purposes. Removing this interaction improves
server throughput by removing processing overhead.

Signed-off-by: Kevin Carter <kecarter@redhat.com>