### PR TITLE
add retry decorator to components

### DIFF
--- a/directord/components/builtin_dnf.py
+++ b/directord/components/builtin_dnf.py
@@ -15,6 +15,7 @@
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import retry
 
 
 class Component(components.ComponentBase):
@@ -47,6 +48,12 @@ class Component(components.ComponentBase):
             nargs="+",
             help="A space delineated list of packages to manage.",
         )
+        self.parser.add_argument(
+            "--retry",
+            default=3,
+            type=int,
+            help="Number of times to retry",
+        )
 
     def server(self, exec_array, data, arg_vars):
         """Return data from formatted transfer action.
@@ -68,12 +75,14 @@ class Component(components.ComponentBase):
         else:
             data["state"] = "present"
 
+        data["retry"] = self.known_args.retry
         data["clear"] = self.known_args.clear_metadata
         data["packages"] = self.known_args.packages
 
         return data
 
     @cacheargs
+    @retry
     def client(self, cache, job):
         """Run file command operation.
 

--- a/directord/components/builtin_run.py
+++ b/directord/components/builtin_run.py
@@ -15,6 +15,7 @@
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import retry
 
 
 class Component(components.ComponentBase):
@@ -32,6 +33,12 @@ class Component(components.ComponentBase):
             action="store_true",
             help="Run a command in 'fire and forget' mode.",
         )
+        self.parser.add_argument(
+            "--retry",
+            default=1,
+            type=int,
+            help="Number of times to retry",
+        )
 
     def server(self, exec_array, data, arg_vars):
         """Return data from formatted transfer action.
@@ -47,11 +54,13 @@ class Component(components.ComponentBase):
 
         super().server(exec_array=exec_array, data=data, arg_vars=arg_vars)
         data["no_block"] = self.known_args.no_block
+        data["retry"] = self.known_args.retry
         data["command"] = " ".join(self.unknown_args)
 
         return data
 
     @cacheargs
+    @retry
     def client(self, cache, job):
         """Run file command operation.
 

--- a/directord/components/builtin_service.py
+++ b/directord/components/builtin_service.py
@@ -15,6 +15,7 @@
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import retry
 
 
 class Component(components.ComponentBase):
@@ -52,6 +53,12 @@ class Component(components.ComponentBase):
             help="Reload the systemd daemon",
         )
         self.parser.add_argument(
+            "--retry",
+            default=3,
+            type=int,
+            help="Number of times to retry",
+        )
+        self.parser.add_argument(
             "services",
             nargs="+",
             help="A space delineated list of services to manage.",
@@ -82,12 +89,14 @@ class Component(components.ComponentBase):
         else:
             data["running"] = "start"
 
+        data["retry"] = self.known_args.retry
         data["services"] = self.known_args.services
         data["daemon_reload"] = self.known_args.daemon_reload
 
         return data
 
     @cacheargs
+    @retry
     def client(self, cache, job):
         """Run service command operation.
 

--- a/directord/components/lib/__init__.py
+++ b/directord/components/lib/__init__.py
@@ -11,6 +11,7 @@
 #   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #   License for the specific language governing permissions and limitations
 #   under the License.
+
 from directord import utils
 
 
@@ -58,6 +59,22 @@ def cacheargs(func):
             arg_job["parent_id"] = utils.get_uuid()
             arg_job["parent_sha3_224"] = utils.object_sha3_224(obj=arg_job)
             self.block_on_tasks.append(arg_job)
+
+        return stdout, stderr, outcome, command
+
+    return wrapper_func
+
+
+def retry(func):
+    """Retry executor."""
+
+    def wrapper_func(*args, **kwargs):
+        retry = kwargs["job"].get("retry", 1)
+        attempt = 0
+        outcome = False
+        while attempt < retry and not outcome:
+            stdout, stderr, outcome, command = func(*args, **kwargs)
+            attempt += 1
 
         return stdout, stderr, outcome, command
 

--- a/directord/tests/test_mixin.py
+++ b/directord/tests/test_mixin.py
@@ -23,12 +23,12 @@ from directord import tests
 
 TEST_FINGER_PRINTS = """count    parent                                                    verb    exec      job
 -------  --------------------------------------------------------  ------  --------  --------------------------------------------------------
-0        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command1  ea5b3554e61a173c25152ad6fe29b178f66b0e3727556995f5816d7e
-1        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command2  a12748d70957f1f2d0ea3d2aae5af73983d8a0563f7b5a0ccd0b2767
-2        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command3  f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd
-3        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command1  ea5b3554e61a173c25152ad6fe29b178f66b0e3727556995f5816d7e
-4        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command2  a12748d70957f1f2d0ea3d2aae5af73983d8a0563f7b5a0ccd0b2767
-5        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command3  f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd"""  # noqa
+0        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command1  e4b6223aa7e089ef41c972df012ea2b7ae309019cf00a35b4b00cf64
+1        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command2  9adf48fd066004bc9cf3e02670e3d1f3971c69dec353717e83be6266
+2        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command3  40a7e8a1ca03e22337791ff51665494440c5463269c88228caa49bc3
+3        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command1  e4b6223aa7e089ef41c972df012ea2b7ae309019cf00a35b4b00cf64
+4        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command2  9adf48fd066004bc9cf3e02670e3d1f3971c69dec353717e83be6266
+5        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command3  40a7e8a1ca03e22337791ff51665494440c5463269c88228caa49bc3"""  # noqa
 
 
 TEST_ORCHESTRATION_READ = """---
@@ -46,6 +46,7 @@ TEST_ORCHESTRATION_READ = """---
 class TestMixin(tests.TestConnectionBase):
     def setUp(self):
         super().setUp()
+        self.maxDiff = None
         self.args = tests.FakeArgs()
         self.mixin = mixin.Mixin(args=self.args)
         self.execute = ["long '{{ jinja }}' quoted string", "string"]
@@ -83,10 +84,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "9bbc435b49b5104da33093b22402c75a263a2d1665bcfc6faa29249e",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                 }
@@ -103,10 +105,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "9bbc435b49b5104da33093b22402c75a263a2d1665bcfc6faa29249e",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test_target"],
@@ -124,10 +127,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "9bbc435b49b5104da33093b22402c75a263a2d1665bcfc6faa29249e",  # noqa
                     "return_raw": False,
                     "skip_cache": True,
                 }
@@ -144,10 +148,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "9bbc435b49b5104da33093b22402c75a263a2d1665bcfc6faa29249e",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "restrict": "Restrictedsha3_224",
@@ -165,10 +170,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "9bbc435b49b5104da33093b22402c75a263a2d1665bcfc6faa29249e",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "parent_id": "ParentID",
@@ -336,10 +342,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "40a7e8a1ca03e22337791ff51665494440c5463269c88228caa49bc3",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test1", "test2", "test3"],
@@ -375,10 +382,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "40a7e8a1ca03e22337791ff51665494440c5463269c88228caa49bc3",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": [
@@ -411,10 +419,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "40a7e8a1ca03e22337791ff51665494440c5463269c88228caa49bc3",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test1", "test2", "test3"],
@@ -446,10 +455,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "40a7e8a1ca03e22337791ff51665494440c5463269c88228caa49bc3",  # noqa
                     "return_raw": False,
                     "skip_cache": True,
                     "targets": ["test1", "test2", "test3"],
@@ -480,10 +490,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "40a7e8a1ca03e22337791ff51665494440c5463269c88228caa49bc3",  # noqa
                     "return_raw": True,
                     "skip_cache": False,
                     "targets": ["test1", "test2", "test3"],
@@ -548,10 +559,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "40a7e8a1ca03e22337791ff51665494440c5463269c88228caa49bc3",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test"],
@@ -579,10 +591,11 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "RUN",
                     "no_block": False,
+                    "retry": 1,
                     "command": "command 1",
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "36796bb09a3838fa2c8bcb802eb9494546289a6fd6ed988579524ee1",  # noqa
+                    "job_sha3_224": "04adb60da1a30eb6da60da3ff967fc4d025c39e45ec1ab021835d946",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test"],


### PR DESCRIPTION
Components can now use retries where they make sense. The new component
retry decorator will make use of the outcome and retry when instructed
to do so.

Components like DNF and SERVICE will retry 3 times by default, while RUN
will run once, but allow operators to specify a retry when desired.

Signed-off-by: Kevin Carter <kecarter@redhat.com>