### PR TITLE
use threading instead of multiprocessing

### DIFF
--- a/.github/workflows/pull-request-functional.yml
+++ b/.github/workflows/pull-request-functional.yml
@@ -109,6 +109,8 @@ jobs:
           sudo cp /etc/directord/messaging/ssl/directord* /tmp/directord
           sudo cp /usr/local/share/ca-certificates/directord/* /tmp/directord
           sudo cp /etc/qpid-dispatch/qdrouterd.* /tmp/directord
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -458,6 +460,8 @@ jobs:
           sudo cp /etc/directord/messaging/ssl/directord* /tmp/directord
           sudo cp /usr/local/share/ca-certificates/directord/* /tmp/directord
           sudo cp /etc/qpid-dispatch/qdrouterd.* /tmp/directord
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()

--- a/components/container_config_data.py
+++ b/components/container_config_data.py
@@ -20,6 +20,7 @@ from directord import components
 from directord import utils
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 # This component was adapted from here:
@@ -91,6 +92,7 @@ class Component(components.ComponentBase):
         data.update(vars(self.known_args))
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache echo command operation.

--- a/components/container_image.py
+++ b/components/container_image.py
@@ -25,6 +25,7 @@ except ImportError:
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -126,6 +127,7 @@ class Component(components.ComponentBase):
             raise AttributeError(msg)
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache echo command operation.

--- a/components/echo.py
+++ b/components/echo.py
@@ -15,6 +15,7 @@
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -46,6 +47,7 @@ class Component(components.ComponentBase):
         data["echo"] = self.known_args.echo
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache echo command operation.

--- a/components/job_wait.py
+++ b/components/job_wait.py
@@ -183,7 +183,7 @@ class Component(components.ComponentBase):
                                     info=info,
                                 )
                                 break
-                            self.delay(0.25)
+                            self.event.wait(0.25)
                         else:
                             self.log.debug(
                                 "Job [ %s ] expected SHA [ %s ] was not"

--- a/components/job_wait.py
+++ b/components/job_wait.py
@@ -17,6 +17,7 @@ import queue
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -66,6 +67,7 @@ class Component(components.ComponentBase):
         data["identity"] = self.known_args.identity
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run file transfer operation.

--- a/components/pod.py
+++ b/components/pod.py
@@ -25,6 +25,7 @@ except ImportError:
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -156,6 +157,7 @@ class Component(components.ComponentBase):
         data["socket_path"] = self.known_args.socket_path
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run pod command operation.

--- a/components/query_wait.py
+++ b/components/query_wait.py
@@ -17,6 +17,7 @@ import time
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -76,6 +77,7 @@ class Component(components.ComponentBase):
         data["identity"] = self.known_args.identity
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache query_wait command operation.

--- a/components/query_wait.py
+++ b/components/query_wait.py
@@ -148,7 +148,7 @@ class Component(components.ComponentBase):
                 )
                 warning_loops = time.time()
 
-            self.delay(0.01)
+            self.event.wait(0.01)
 
         if missing_identity:
             info = (

--- a/components/reboot.py
+++ b/components/reboot.py
@@ -15,6 +15,7 @@
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -50,6 +51,7 @@ class Component(components.ComponentBase):
         data["time"] = self.known_args.time
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache restart command operation.

--- a/components/secontext.py
+++ b/components/secontext.py
@@ -15,6 +15,7 @@
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 try:
@@ -129,6 +130,7 @@ class Component(components.ComponentBase):
 
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache echo command operation.

--- a/directord/__init__.py
+++ b/directord/__init__.py
@@ -142,7 +142,7 @@ class Processor:
     if cpu_count > 16:
         cpu_count = 16
 
-    thread = threading.Thread
+    thread = multiprocessing.Process
 
     def __init__(self):
         """Initialize Processor class."""

--- a/directord/__init__.py
+++ b/directord/__init__.py
@@ -12,15 +12,14 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-import contextlib
 import importlib
 import importlib.util as importlib_util
 import json
 import multiprocessing
 import os
-import signal
 import socket
 import sys
+import threading
 
 from types import SimpleNamespace
 
@@ -143,14 +142,10 @@ class Processor:
     if cpu_count > 16:
         cpu_count = 16
 
-    thread = multiprocessing.Process
+    thread = threading.Thread
 
     def __init__(self):
-        """Initialize Processor class creating all required manager objects.
-
-        Managers maintain a multiprocessing proxy object which allows data to
-        be shared across threads.
-        """
+        """Initialize Processor class."""
 
         self.log = logger.getLogger(name="directord")
 
@@ -162,13 +157,13 @@ class Processor:
 
     @staticmethod
     def get_lock():
-        """Returns a multiprocessing lock."""
+        """Returns a thread lock."""
 
         return multiprocessing.Lock()
 
     @staticmethod
     def get_queue():
-        """Returns a multiprocessing queue."""
+        """Returns a queue."""
 
         return multiprocessing.Queue()
 
@@ -178,7 +173,7 @@ class Processor:
         * If the process object is null, return False
         * If the process is in an "alive", return False.
 
-        :param process: Multiprocessing object.
+        :param process: Thread object.
         :type process: Object
         :returns: Boolean
         """
@@ -188,8 +183,7 @@ class Processor:
 
         try:
             if not process.is_alive():
-                process.join(timeout=0.1)
-                process.terminate()
+                process.join(timeout=1)
                 self.log.info("Process [ %s ] cleaned up", process.name)
                 return True
         except Exception as e:
@@ -222,40 +216,6 @@ class Processor:
 
         for t, _ in threads:
             t.join()
-
-    @contextlib.contextmanager
-    def timeout(self, time, job_id, reraise=False):
-        """Registers a context manager to raise whenever a timeout occurs.
-
-        :param time: Time in seconds before an alarm is raised.
-        :type time: Integer
-        :param job_id: Job UUID
-        :type job_id: String
-        :param reraise: Reraise the timeout exception
-        :type reraise: Boolean
-        :yields:
-        """
-
-        signal.signal(signal.SIGALRM, self.raise_timeout)
-        signal.alarm(time)
-        try:
-            yield
-        except TimeoutError:
-            self.log.warning(
-                "Timeout encountered after [ %s ] seconds running [ %s ].",
-                time,
-                job_id,
-            )
-            if reraise:
-                raise TimeoutError
-        finally:
-            signal.signal(signal.SIGALRM, signal.SIG_IGN)
-
-    def raise_timeout(self, *args, **kwargs):
-        """Log, then raise a Timeout error."""
-
-        self.log.error("Task timeout encountered.")
-        raise TimeoutError
 
 
 class UNIXSocketConnect:
@@ -488,7 +448,7 @@ class Spinner(object):
         :type queue: Object
         """
 
-        self.job = multiprocessing.Process(target=self.indicator, daemon=True)
+        self.job = threading.Thread(target=self.indicator, daemon=True)
         self.pipe_a, self.pipe_b = multiprocessing.Pipe()
         self.run = run
         self.queue = queue
@@ -506,7 +466,6 @@ class Spinner(object):
             self.run = False
             self.pipe_a.close()
             self.pipe_b.close()
-            self.job.terminate()
             print("Done.")
 
     def indicator_msg(self, msg):

--- a/directord/bootstrap.py
+++ b/directord/bootstrap.py
@@ -389,48 +389,41 @@ class Bootstrap(directord.Processor):
                 for job in self.bootstrap_flatten_jobs(jobs=job_def["jobs"]):
                     key, value = next(iter(job.items()))
                     self.log.debug("Executing: %s %s", key, value)
-                    with self.timeout(
-                        time=600, job_id=job_def["host"], reraise=True
-                    ):
-                        if self.indicator:
-                            msg = self.indicator.indicator_msg(
-                                msg="Executing {} to {}".format(
-                                    key, job_def["host"]
-                                )
+                    if self.indicator:
+                        msg = self.indicator.indicator_msg(
+                            msg="Executing {} to {}".format(
+                                key, job_def["host"]
                             )
-                            if msg:
-                                self.log.info(msg)
-                        else:
-                            self.log.info(
-                                "Connecting to [ %s ]", job_def["host"]
-                            )
-                        if key == "RUN":
-                            self.bootstrap_exec(
-                                ssh=ssh, command=value, catalog=catalog
-                            )
-                        elif key == "ADD":
-                            value = self._blueprinter(
-                                string=value, catalog=catalog
-                            )
-                            localfile, remotefile = value.split(" ", 1)
-                            localfile = self.bootstrap_localfile_padding(
-                                localfile
-                            )
-                            self.bootstrap_file_send(
-                                ssh=ssh,
-                                localfile=localfile,
-                                remotefile=remotefile,
-                            )
-                        elif key == "GET":
-                            value = self._blueprinter(
-                                string=value, catalog=catalog
-                            )
-                            remotefile, localfile = value.split(" ", 1)
-                            self.bootstrap_file_get(
-                                ssh=ssh,
-                                localfile=localfile,
-                                remotefile=remotefile,
-                            )
+                        )
+                        if msg:
+                            self.log.info(msg)
+                    else:
+                        self.log.info("Connecting to [ %s ]", job_def["host"])
+                    if key == "RUN":
+                        self.bootstrap_exec(
+                            ssh=ssh, command=value, catalog=catalog
+                        )
+                    elif key == "ADD":
+                        value = self._blueprinter(
+                            string=value, catalog=catalog
+                        )
+                        localfile, remotefile = value.split(" ", 1)
+                        localfile = self.bootstrap_localfile_padding(localfile)
+                        self.bootstrap_file_send(
+                            ssh=ssh,
+                            localfile=localfile,
+                            remotefile=remotefile,
+                        )
+                    elif key == "GET":
+                        value = self._blueprinter(
+                            string=value, catalog=catalog
+                        )
+                        remotefile, localfile = value.split(" ", 1)
+                        self.bootstrap_file_get(
+                            ssh=ssh,
+                            localfile=localfile,
+                            remotefile=remotefile,
+                        )
         except OSError as e:
             print(
                 "\nFailed to connect to [ {} ]: {}\n".format(

--- a/directord/client.py
+++ b/directord/client.py
@@ -183,7 +183,7 @@ class Client(interface.Interface):
 
                 _parent["q"].put((component_kwargs, command, info))
                 if not _parent["t"]:
-                    _parent["t"] = self.thread(
+                    _parent["t"] = self.driver.thread_processor(
                         target=self.q_processor,
                         kwargs=dict(
                             queue=_parent["q"],
@@ -221,7 +221,9 @@ class Client(interface.Interface):
                             key,
                         )
                         parent_tracker[key].pop("timeout", None)
-                        parent_tracker[key]["t"] = self.thread(
+                        parent_tracker[key][
+                            "t"
+                        ] = self.driver.thread_processor(
                             target=self.q_processor,
                             kwargs=dict(
                                 queue=parent_tracker[key]["q"],
@@ -685,7 +687,7 @@ class Client(interface.Interface):
                 run_q_processor_thread = None
 
             if not self.q_processes.empty() and not run_q_processor_thread:
-                run_q_processor_thread = self.thread(
+                run_q_processor_thread = self.driver.thread_processor(
                     target=self.job_q_processor,
                     kwargs=dict(q_processes=self.q_processes, lock=lock),
                     name="job_q_processor",

--- a/directord/client.py
+++ b/directord/client.py
@@ -47,7 +47,7 @@ class Client(interface.Interface):
     def q_processor(self, queue, lock):
         """Process jobs from the known queue.
 
-        :param queue: Multiprocessing queue object.
+        :param queue: queue object.
         :type queue: Object
         :param lock: Locking object, used if a component requires it.
         :type lock: Object
@@ -91,7 +91,7 @@ class Client(interface.Interface):
                 for i in parents.values()
                 if i["bypass"]
                 and not i["t"].is_alive()
-                and i["t"].exitcode is None
+                and i["t"].ident is None
             ]
 
         def _get_pending_threads(parents):
@@ -107,7 +107,7 @@ class Client(interface.Interface):
                 for i in parents.values()
                 if not i["bypass"]
                 and not i["t"].is_alive()
-                and i["t"].exitcode is None
+                and i["t"].ident is None
             ]
 
         def _get_thread_count(parents):
@@ -205,15 +205,13 @@ class Client(interface.Interface):
                     break
 
             for key, value in list(parent_tracker.items()):
-                if value["t"].is_alive() or value["t"].exitcode is None:
+                if value["t"].is_alive() or value["t"].ident is None:
                     continue
                 else:
                     timestamp = time.time()
                     timeout = timestamp - value.get("timeout", timestamp) > 5
                     if value["q"].empty() and timeout:
                         self.terminate_process(process=value["t"])
-                        value["q"].close()
-                        value["q"].join_thread()
                         parent_tracker.pop(key)
                         self.log.info("Pruned parent [ %s ]", key)
                     elif not value["q"].empty():
@@ -372,19 +370,13 @@ class Client(interface.Interface):
                 locked = lock.acquire()
                 self.log.debug("Lock acquired for [ %s ]", job_id)
 
-            with self.timeout(
-                time=job.get("timeout", 600),
-                job_id=job_id,
-            ):
-                _starttime = time.time()
-                stdout, stderr, outcome, info = component.client(
-                    cache=self.cache, job=job
-                )
-                job[
-                    "component_exec_timestamp"
-                ] = datetime.datetime.fromtimestamp(time.time()).strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                )
+            _starttime = time.time()
+            stdout, stderr, outcome, info = component.client(
+                cache=self.cache, job=job
+            )
+            job["component_exec_timestamp"] = datetime.datetime.fromtimestamp(
+                time.time()
+            ).strftime("%Y-%m-%d %H:%M:%S")
 
             try:
                 if component.block_on_tasks:
@@ -446,27 +438,21 @@ class Client(interface.Interface):
                 )
                 self.log.debug("Job call backs: %s ", component.block_on_tasks)
                 block_on_task_success = False
-                with self.timeout(
-                    time=block_on_task_data.get("timeout", 600),
-                    job_id=block_on_task_data["job_id"],
-                ):
-                    while True:
-                        if self.cache.get(
-                            block_on_task_data["job_sha3_224"]
-                        ) in [
-                            self.driver.job_end,
-                            self.driver.job_failed,
-                        ]:
-                            block_on_task_success = True
-                            break
-                        else:
-                            self.log.debug(
-                                "waiting for callback job from [ %s ] to"
-                                " complete. %s",
-                                job["job_id"],
-                                block_on_task_data,
-                            )
-                            time.sleep(1)
+                while True:
+                    if self.cache.get(block_on_task_data["job_sha3_224"]) in [
+                        self.driver.job_end,
+                        self.driver.job_failed,
+                    ]:
+                        block_on_task_success = True
+                        break
+                    else:
+                        self.log.debug(
+                            "waiting for callback job from [ %s ] to"
+                            " complete. %s",
+                            job["job_id"],
+                            block_on_task_data,
+                        )
+                        time.sleep(1)
 
                 if block_on_task_success:
                     self.log.debug(
@@ -840,7 +826,7 @@ class Client(interface.Interface):
 
         threads = [
             (
-                self.thread(
+                self.driver.thread_processor(
                     name="run_job", target=self.run_job, kwargs=dict(lock=lock)
                 ),
                 False,

--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -17,7 +17,7 @@ import os
 import subprocess
 import time
 
-from multiprocessing import Event
+from threading import Event
 
 import jinja2
 from jinja2 import StrictUndefined
@@ -37,7 +37,7 @@ class ComponentBase:
     verb = None
     block_on_tasks = None
     queue_sentinel = False
-    delay = Event().wait
+    event = Event()
 
     def __init__(self, desc=None):
         """Initialize the component base class.

--- a/directord/components/builtin_arg.py
+++ b/directord/components/builtin_arg.py
@@ -18,6 +18,7 @@ import json
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -81,6 +82,7 @@ class Component(components.ComponentBase):
         data[self.cache_type] = {key: value}
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache command operation.

--- a/directord/components/builtin_cacheevict.py
+++ b/directord/components/builtin_cacheevict.py
@@ -15,6 +15,7 @@
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -58,6 +59,7 @@ class Component(components.ComponentBase):
         data["cacheevict"] = self.known_args.cacheevict
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache evict command operation.

--- a/directord/components/builtin_cachefile.py
+++ b/directord/components/builtin_cachefile.py
@@ -19,6 +19,7 @@ import yaml
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -57,6 +58,7 @@ class Component(components.ComponentBase):
         data["cachefile"] = self.known_args.cachefile
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache file operation.

--- a/directord/components/builtin_copy.py
+++ b/directord/components/builtin_copy.py
@@ -24,6 +24,7 @@ from directord import components
 from directord import utils
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -88,6 +89,7 @@ class Component(components.ComponentBase):
 
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run file transfer operation.

--- a/directord/components/builtin_dnf.py
+++ b/directord/components/builtin_dnf.py
@@ -16,6 +16,7 @@ from directord import components
 
 from directord.components.lib import cacheargs
 from directord.components.lib import retry
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -81,6 +82,7 @@ class Component(components.ComponentBase):
 
         return data
 
+    @timeout
     @cacheargs
     @retry
     def client(self, cache, job):

--- a/directord/components/builtin_query.py
+++ b/directord/components/builtin_query.py
@@ -18,6 +18,7 @@ from directord import components
 from directord import utils
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -69,6 +70,7 @@ class Component(components.ComponentBase):
         data["no_wait"] = self.known_args.no_wait
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run query command operation.

--- a/directord/components/builtin_queuesentinel.py
+++ b/directord/components/builtin_queuesentinel.py
@@ -15,6 +15,7 @@
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -55,6 +56,7 @@ class Component(components.ComponentBase):
         data["parent_async_bypass"] = True
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run cache command operation.

--- a/directord/components/builtin_run.py
+++ b/directord/components/builtin_run.py
@@ -16,6 +16,7 @@ from directord import components
 
 from directord.components.lib import cacheargs
 from directord.components.lib import retry
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -59,6 +60,7 @@ class Component(components.ComponentBase):
 
         return data
 
+    @timeout
     @cacheargs
     @retry
     def client(self, cache, job):

--- a/directord/components/builtin_service.py
+++ b/directord/components/builtin_service.py
@@ -16,6 +16,7 @@ from directord import components
 
 from directord.components.lib import cacheargs
 from directord.components.lib import retry
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -95,6 +96,7 @@ class Component(components.ComponentBase):
 
         return data
 
+    @timeout
     @cacheargs
     @retry
     def client(self, cache, job):

--- a/directord/components/builtin_wait.py
+++ b/directord/components/builtin_wait.py
@@ -18,6 +18,7 @@ import time
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -91,6 +92,7 @@ class Component(components.ComponentBase):
         data["insecure"] = self.known_args.insecure
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Wait for condition.

--- a/directord/components/builtin_workdir.py
+++ b/directord/components/builtin_workdir.py
@@ -20,6 +20,7 @@ import traceback
 from directord import components
 
 from directord.components.lib import cacheargs
+from directord.components.lib import timeout
 
 
 class Component(components.ComponentBase):
@@ -63,6 +64,7 @@ class Component(components.ComponentBase):
         data["workdir"] = self.known_args.workdir
         return data
 
+    @timeout
     @cacheargs
     def client(self, cache, job):
         """Run file work directory operation.

--- a/directord/components/lib/__init__.py
+++ b/directord/components/lib/__init__.py
@@ -79,3 +79,18 @@ def retry(func):
         return stdout, stderr, outcome, command
 
     return wrapper_func
+
+
+def timeout(func):
+    """Decorator to raise whenever a timeout occurs.
+
+    NotImplemented - Rework this functiont to better support threads and
+    processes.
+
+    :returns: Tuple
+    """
+
+    def wrapper_func(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper_func

--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -14,6 +14,7 @@
 
 import socket
 import time
+import threading
 
 from directord import logger
 
@@ -39,6 +40,7 @@ class BaseDriver:
     nullbyte = "\x00"  # Signals null
     transfer_start = "\x02"  # Signals transfer start
     transfer_end = "\x03"  # Signals transfer end
+    thread_processor = threading.Thread
 
     def __init__(
         self,

--- a/directord/drivers/messaging.py
+++ b/directord/drivers/messaging.py
@@ -14,9 +14,9 @@
 
 import json
 import logging
-import multiprocessing
 import os
 import pkg_resources
+import queue
 import time
 
 try:
@@ -151,9 +151,9 @@ class Driver(drivers.BaseDriver):
         self.transport = self._rpc_transport()
         self.server = None
         self.backend_server = None
-        self.job_q = multiprocessing.Queue()
-        self.backend_q = multiprocessing.Queue()
-        self.send_q = multiprocessing.Queue()
+        self.job_q = queue.Queue()
+        self.backend_q = queue.Queue()
+        self.send_q = queue.Queue()
         self.process_send_q = None
         self.timeout = 1
 

--- a/directord/drivers/zmq.py
+++ b/directord/drivers/zmq.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+import multiprocessing
 import os
 import time
 
@@ -112,6 +113,7 @@ class Driver(drivers.BaseDriver):
         :type interface: Object
         """
 
+        self.thread_processor = multiprocessing.Process
         self.args = args
         self.encrypted_traffic_data = encrypted_traffic_data
 

--- a/directord/server.py
+++ b/directord/server.py
@@ -567,7 +567,7 @@ class Server(interface.Interface):
 
             if not self.job_queue.empty():
                 if not run_jobs_thread:
-                    run_jobs_thread = self.thread(
+                    run_jobs_thread = self.driver.thread_processor(
                         target=self.run_job,
                         name="run_job",
                         daemon=True,
@@ -623,7 +623,9 @@ class Server(interface.Interface):
                         self.log.info(
                             "Job [ %s ], QUERY command found", msg_id
                         )
-                        t = coordination_threads[msg_id] = self.thread(
+                        t = coordination_threads[
+                            msg_id
+                        ] = self.driver.thread_processor(
                             target=self._query_coordination,
                             name=msg_id,
                             daemon=True,

--- a/directord/tests/test_init.py
+++ b/directord/tests/test_init.py
@@ -12,7 +12,6 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-import time
 import unittest
 
 from unittest import mock
@@ -158,23 +157,6 @@ class TestProcessor(unittest.TestCase):
         self.processor.run_threads(threads=[(thread1, False), (thread2, True)])
         self.assertFalse(thread1.daemon)
         self.assertTrue(thread2.daemon)
-
-    def test_timeout_error_reraise(self):
-        with self.assertRaises(TimeoutError):
-            with self.processor.timeout(1, "test-job_id", reraise=True):
-                time.sleep(5)
-
-    def test_timeout_error(self):
-        with self.processor.timeout(1, "test-job_id"):
-            time.sleep(5)
-
-    def test_timeout(self):
-        with self.processor.timeout(5, "test-job_id"):
-            time.sleep(1)
-
-    def test_raise_timeout(self):
-        with self.assertRaises(TimeoutError):
-            self.processor.raise_timeout()
 
 
 class TestUnixSocket(unittest.TestCase):
@@ -341,7 +323,7 @@ class TestDirectordInit(unittest.TestCase):
 
 class TestIndicator(unittest.TestCase):
     def setUp(self):
-        self.multi_patched = mock.patch("directord.multiprocessing.Process")
+        self.multi_patched = mock.patch("directord.threading.Thread")
         self.multi = self.multi_patched.start()
 
     def tearDown(self):

--- a/directord/utils.py
+++ b/directord/utils.py
@@ -22,7 +22,7 @@ import sys
 import time
 import uuid
 
-import multiprocessing
+import threading
 
 import tabulate
 import yaml
@@ -366,12 +366,12 @@ def component_lock_search():
 
 
 class Locker:
-    """Context manager for multiprocessing lock object."""
+    """Context manager for threading lock object."""
 
     def __init__(self, lock):
         """Initialize the lock context manager.
 
-        :param lock: Multiprocessing lock object
+        :param lock: threading lock object
         :type lock: Object
         """
 
@@ -409,7 +409,7 @@ class Cache:
         """
 
         self.log = logger.getLogger(name="directord-cache")
-        self.lock = multiprocessing.Lock()
+        self.lock = threading.Lock()
         self.db_path = os.path.abspath(os.path.expanduser(url))
         os.makedirs(self.db_path, exist_ok=True)
         try:

--- a/directord/utils.py
+++ b/directord/utils.py
@@ -22,7 +22,7 @@ import sys
 import time
 import uuid
 
-import threading
+import multiprocessing
 
 import tabulate
 import yaml
@@ -366,12 +366,12 @@ def component_lock_search():
 
 
 class Locker:
-    """Context manager for threading lock object."""
+    """Context manager for multiprocessing lock object."""
 
     def __init__(self, lock):
         """Initialize the lock context manager.
 
-        :param lock: threading lock object
+        :param lock: Multiprocessing lock object
         :type lock: Object
         """
 
@@ -409,7 +409,7 @@ class Cache:
         """
 
         self.log = logger.getLogger(name="directord-cache")
-        self.lock = threading.Lock()
+        self.lock = multiprocessing.Lock()
         self.db_path = os.path.abspath(os.path.expanduser(url))
         os.makedirs(self.db_path, exist_ok=True)
         try:


### PR DESCRIPTION
While the multiprocessing API should work for our purposes, the use of
multiprocessing can cause issues with different drivers. This change
modifies directord to make use of the threading library and native queue
functions instead of relying on multiprocessing, which should ensure it
is more compatible with different backends.

Signed-off-by: Kevin Carter <kecarter@redhat.com>