### PR TITLE
Add coroutine timeout decorator

### DIFF
--- a/directord/components/lib/__init__.py
+++ b/directord/components/lib/__init__.py
@@ -12,6 +12,8 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
+import asyncio
+
 from directord import utils
 
 
@@ -82,15 +84,30 @@ def retry(func):
 
 
 def timeout(func):
-    """Decorator to raise whenever a timeout occurs.
+    """Timeout coroutine."""
 
-    NotImplemented - Rework this functiont to better support threads and
-    processes.
-
-    :returns: Tuple
-    """
+    async def _main(*args, **kwargs):
+        self = args[0]
+        user_timeout = float(kwargs["job"].get("timeout", 600))
+        self.log.debug(
+            "Job [ %s ] running, timeout set for %s.",
+            kwargs["job"].get("job_id"),
+            user_timeout,
+        )
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(None, lambda: func(*args, **kwargs))
+        try:
+            return await asyncio.wait_for(future, timeout=user_timeout)
+        except asyncio.exceptions.TimeoutError:
+            self.log.warning(
+                "Job [ %s ] timeout after %s.",
+                kwargs["job"].get("job_id"),
+                user_timeout,
+            )
+            future.cancel()
+            return None, "Timeout encountered", False, None
 
     def wrapper_func(*args, **kwargs):
-        return func(*args, **kwargs)
+        return asyncio.run(_main(*args, **kwargs))
 
     return wrapper_func


### PR DESCRIPTION
The timeout function was removed because it was not compatible with
threads. This change reimplements the timeout function on directord
client interactions using an async coroutine.

Signed-off-by: Kevin Carter <kecarter@redhat.com>