### PR TITLE
ensure that drivers use process based locks

### DIFF
--- a/directord/__init__.py
+++ b/directord/__init__.py
@@ -155,12 +155,6 @@ class Processor:
         return multiprocessing.Manager()
 
     @staticmethod
-    def get_lock():
-        """Returns a thread lock."""
-
-        return multiprocessing.Lock()
-
-    @staticmethod
     def get_queue():
         """Returns a queue."""
 

--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -12,6 +12,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
+import queue
 import socket
 import time
 import threading
@@ -69,6 +70,18 @@ class BaseDriver:
             self.machine_id = self.get_machine_id()
 
         self.interface = interface
+
+    @staticmethod
+    def get_lock():
+        """Returns a thread lock."""
+
+        return threading.Lock()
+
+    @staticmethod
+    def get_queue():
+        """Returns a thread lock."""
+
+        return queue.Queue()
 
     def __copy__(self):
         """Return a copy of the base class.

--- a/directord/drivers/zmq.py
+++ b/directord/drivers/zmq.py
@@ -701,6 +701,18 @@ class Driver(drivers.BaseDriver):
         kwargs["socket"] = self.bind_backend
         return self._socket_send(*args, **kwargs)
 
+    @staticmethod
+    def get_lock():
+        """Returns a thread lock."""
+
+        return multiprocessing.Lock()
+
+    @staticmethod
+    def get_queue():
+        """Returns a thread lock."""
+
+        return multiprocessing.Queue()
+
     def key_generate(self, keys_dir, key_type):
         """Generate certificate.
 

--- a/directord/server.py
+++ b/directord/server.py
@@ -40,8 +40,8 @@ class Server(interface.Interface):
         """
 
         super(Server, self).__init__(args=args)
-        self.job_queue = self.get_queue()
-        self.send_queue = self.get_queue()
+        self.job_queue = self.driver.get_queue()
+        self.send_queue = self.driver.get_queue()
         datastore = getattr(self.args, "datastore", None)
         self.workers = dict()
         if not datastore or datastore == "memory":

--- a/directord/tests/test_drivers_messaging.py
+++ b/directord/tests/test_drivers_messaging.py
@@ -41,6 +41,16 @@ class TestDriverMessaging(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_get_lock(self):
+        with patch("threading.Lock") as mock_lock:
+            self.driver.get_lock()
+            mock_lock.assert_called()
+
+    def test_get_queue(self):
+        with patch("queue.Queue") as mock_queue:
+            self.driver.get_queue()
+            mock_queue.assert_called()
+
     @patch("directord.utils.get_uuid", autospec=True)
     @patch("directord.drivers.messaging.Driver._send")
     def test_heartbeat_send(self, mock_send, mock_get_uuid):

--- a/directord/tests/test_drivers_zmq.py
+++ b/directord/tests/test_drivers_zmq.py
@@ -30,6 +30,16 @@ class TestDriverZMQSharedAuth(unittest.TestCase):
         self.driver.secret_keys_dir = "test/key"
         self.driver.public_keys_dir = "test/key"
 
+    def test_get_lock(self):
+        with patch("multiprocessing.Lock") as mock_lock:
+            self.driver.get_lock()
+            mock_lock.assert_called()
+
+    def test_get_queue(self):
+        with patch("multiprocessing.Queue") as mock_queue:
+            self.driver.get_queue()
+            mock_queue.assert_called()
+
     @patch("logging.Logger.info", autospec=True)
     def test_socket_connect_curve_auth(self, mock_info_logging):
         m = unittest.mock.mock_open(read_data=tests.MOCK_CURVE_KEY.encode())

--- a/directord/tests/test_init.py
+++ b/directord/tests/test_init.py
@@ -141,11 +141,6 @@ class TestProcessor(unittest.TestCase):
     def tearDown(self):
         self.log_patched.stop()
 
-    def test_get_lock(self):
-        with patch("multiprocessing.Lock") as mock_lock:
-            self.processor.get_lock()
-            mock_lock.assert_called()
-
     def test_get_queue(self):
         with patch("multiprocessing.Queue") as mock_queue:
             self.processor.get_queue()

--- a/directord/utils.py
+++ b/directord/utils.py
@@ -22,8 +22,6 @@ import sys
 import time
 import uuid
 
-import multiprocessing
-
 import tabulate
 import yaml
 
@@ -366,7 +364,7 @@ def component_lock_search():
 
 
 class Locker:
-    """Context manager for multiprocessing lock object."""
+    """Context manager for lock object."""
 
     def __init__(self, lock):
         """Initialize the lock context manager.
@@ -383,17 +381,20 @@ class Locker:
         :returns: Object
         """
 
-        self.lock.acquire()
+        if self.lock:
+            self.lock.acquire()
+
         return self.lock
 
     def __exit__(self, *args, **kwargs):
         """Exit the lock context manager."""
 
-        self.lock.release()
+        if self.lock:
+            self.lock.release()
 
 
 class Cache:
-    def __init__(self, url):
+    def __init__(self, url, lock=None):
         """Initialize the POSIX compatible datastore.
 
         The POSIX cache store uses xattrs to store metadata about stored
@@ -406,10 +407,12 @@ class Cache:
 
         :param url: Connection string to the file backend.
         :type url: String
+        :param lock: Lock type object
+        :type lock: Object
         """
 
         self.log = logger.getLogger(name="directord-cache")
-        self.lock = multiprocessing.Lock()
+        self.lock = lock
         self.db_path = os.path.abspath(os.path.expanduser(url))
         os.makedirs(self.db_path, exist_ok=True)
         try:


### PR DESCRIPTION
Locks can not be mixed and matched, this change ensures that the driver
code, which is responcible for the process execution is selecting the
correct lock types.

Signed-off-by: Kevin Carter <kecarter@redhat.com>