### PR TITLE
Ensure components have unique locks

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -354,7 +354,9 @@ class Client(interface.Interface):
 
             locked = False
             if component.requires_lock:
-                lock_name = "__lock_{}__".format(command_lower)
+                lock_name = "__lock_{}__".format(
+                    getattr(component, "lock_name", command_lower)
+                )
                 try:
                     lock = getattr(self, lock_name)
                 except AttributeError:

--- a/directord/components/builtin_arg.py
+++ b/directord/components/builtin_arg.py
@@ -33,6 +33,7 @@ class Component(components.ComponentBase):
         super().__init__(desc="Process cache commands")
         self.cacheable = False
         self.requires_lock = True
+        self.lock_name = "arg"  # ENV and ARG are aliases
         self.cache_type = None
 
     def args(self):

--- a/directord/components/builtin_copy.py
+++ b/directord/components/builtin_copy.py
@@ -33,6 +33,7 @@ class Component(components.ComponentBase):
 
         super().__init__(desc="Process transfer commands")
         self.requires_lock = True
+        self.lock_name = "copy"  # ADD and COPY are aliases
 
     def args(self):
         """Set default arguments for a component."""

--- a/directord/utils.py
+++ b/directord/utils.py
@@ -351,12 +351,17 @@ def component_lock_search():
     if sys.base_prefix != sys.prefix:
         paths.insert(0, os.path.join(sys.prefix, "share/directord/components"))
 
-    lock_commands = list()
+    lock_commands = set()
     for importer, name, _ in pkgutil.iter_modules(paths):
         component = importer.find_module(name).load_module(name)
         try:
-            if component.Component().requires_lock:
-                lock_commands.append(name.lstrip("builtin_"))
+            component_obj = component.Component()
+            if component_obj.requires_lock:
+                lock_commands.add(
+                    getattr(
+                        component_obj, "lock_name", name.lstrip("builtin_")
+                    )
+                )
         except AttributeError:
             pass
     else:


### PR DESCRIPTION
Some components are aliases, which are there for ease of use, however,
these aliaes need to have unique locks.

Signed-off-by: Kevin Carter <kecarter@redhat.com>