### PR TITLE
Remove messaging drivers entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,6 @@ setuptools.setup(
             "directord-server-systemd = directord.main:_systemd_server",
             "directord-client-systemd = directord.main:_systemd_client",
         ],
-        "directord.drivers": [
-            "messaging = directord.drivers.messaging",
-        ],
     },
     data_files=[
         (


### PR DESCRIPTION
The entrypoint for drivers is no longer needed as the entrypoint loading
code was removed in cd59fcd6ccdfee4dff44ffde4a4154a02ff6b0d3.

Signed-off-by: James Slagle <jslagle@redhat.com>
