### PR TITLE
Create thread exception class and terminate events

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -663,7 +663,7 @@ class Client(interface.Interface):
         else:
             return True
 
-    def run_job(self, lock=None, sentinel=False):
+    def run_job(self, lock=None):
         """Job entry point.
 
         This creates a cached access object, connects to the socket and begins
@@ -674,9 +674,6 @@ class Client(interface.Interface):
 
         * Initial poll interval is 1024, maxing out at 2048. When work is
           present, the poll interval is 1.
-
-        :param sentinel: Breaks the loop
-        :type sentinel: Boolean
         """
 
         self.driver.job_init()
@@ -736,7 +733,7 @@ class Client(interface.Interface):
                 log=self.log,
             )
 
-            if sentinel:
+            if self.driver.event.is_set():
                 self.driver.job_close()
                 break
 
@@ -841,4 +838,4 @@ class Client(interface.Interface):
             lock=self.driver.get_lock(),
         ) as cache:
             self.cache = cache
-            self.run_threads(threads=threads)
+            self.run_threads(threads=threads, stop_event=self.driver.event)

--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -30,6 +30,22 @@ def parse_args(parser):
     pass
 
 
+class ExceptionThreadProcessor(threading.Thread):
+    """Create an exception handling thread class."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exception = None
+
+    def run(self):
+        """Run, but wrapped to store any encountered exception."""
+
+        try:
+            super().run()
+        except Exception as e:
+            self.exception = e
+
+
 class BaseDriver:
     coordination_failed = "\x07"  # Signals coordination failed
     coordination_ack = "\x10"  # Signals coordination acknowledged
@@ -41,7 +57,7 @@ class BaseDriver:
     nullbyte = "\x00"  # Signals null
     transfer_start = "\x02"  # Signals transfer start
     transfer_end = "\x03"  # Signals transfer end
-    thread_processor = threading.Thread
+    thread_processor = ExceptionThreadProcessor
     event = threading.Event()
 
     def __init__(

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -216,10 +216,13 @@ class FakeCache:
 class FakeThread:
     daemon = False
 
+    def is_alive(self):
+        pass
+
     def start(self):
         pass
 
-    def join(self):
+    def join(self, *args, **kwargs):
         pass
 
 
@@ -262,6 +265,9 @@ class TestDriverBase(unittest.TestCase):
         self.mock_driver.transfer_end = base_driver.transfer_end
         self.mock_driver.bind_job = MagicMock()
         self.mock_driver.heartbeat_send = MagicMock()
+        event = self.mock_driver.event = MagicMock()
+        event.is_set.return_value = True
+
         self.addCleanup(self.restoreDrivers)
 
     def restoreDrivers(self):

--- a/directord/tests/test_client.py
+++ b/directord/tests/test_client.py
@@ -50,7 +50,7 @@ class TestClient(tests.TestDriverBase):
         ]
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check", return_value=False):
-            self.client.run_job(sentinel=True)
+            self.client.run_job()
 
     @patch("time.time", autospec=True)
     def test_run_job_idle(self, mock_time):
@@ -74,7 +74,7 @@ class TestClient(tests.TestDriverBase):
         ]
         mock_time.side_effect = [1, 1, 66, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check", return_value=False):
-            self.client.run_job(sentinel=True)
+            self.client.run_job()
 
     @patch("time.time", autospec=True)
     def test_run_job_ramp(self, mock_time):
@@ -98,7 +98,7 @@ class TestClient(tests.TestDriverBase):
         ]
         mock_time.side_effect = [1, 1, 1, 34, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check", return_value=False):
-            self.client.run_job(sentinel=True)
+            self.client.run_job()
 
     @patch("shelve.open", autospec=True)
     @patch("time.time", autospec=True)
@@ -128,7 +128,7 @@ class TestClient(tests.TestDriverBase):
         mock_time.side_effect = [1, 1, 1, 1, 5000, 1, 1, 1, 1, 1]
         mock_diskcache.return_value = tests.FakeCache()
         with patch.object(self.mock_driver, "job_check", return_value=False):
-            self.client.run_job(sentinel=True)
+            self.client.run_job()
 
     @patch("shelve.open", autospec=True)
     @patch("logging.Logger.debug", autospec=True)
@@ -161,7 +161,7 @@ class TestClient(tests.TestDriverBase):
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]
-            self.client.run_job(sentinel=True)
+            self.client.run_job()
         mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
@@ -196,7 +196,7 @@ class TestClient(tests.TestDriverBase):
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]
-            self.client.run_job(sentinel=True)
+            self.client.run_job()
         mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
@@ -230,7 +230,7 @@ class TestClient(tests.TestDriverBase):
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]
-            self.client.run_job(sentinel=True)
+            self.client.run_job()
         mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
@@ -266,7 +266,7 @@ class TestClient(tests.TestDriverBase):
         with patch.object(self.client, "cache", cache):
             with patch.object(self.mock_driver, "job_check") as mock_job_check:
                 mock_job_check.side_effect = [True, False]
-                self.client.run_job(sentinel=True)
+                self.client.run_job()
         mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
@@ -303,7 +303,7 @@ class TestClient(tests.TestDriverBase):
         with patch.object(self.client, "cache", cache):
             with patch.object(self.mock_driver, "job_check") as mock_job_check:
                 mock_job_check.side_effect = [True, False]
-                self.client.run_job(sentinel=True)
+                self.client.run_job()
         mock_log_info.assert_called()
         self.assertEqual(cache.get("YYY"), self.mock_driver.job_end)
 
@@ -339,7 +339,7 @@ class TestClient(tests.TestDriverBase):
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]
-            self.client.run_job(sentinel=True)
+            self.client.run_job()
         mock_log_info.assert_called()
         self.assertEqual(cache.get("YYY"), self.mock_driver.job_failed)
 
@@ -347,5 +347,5 @@ class TestClient(tests.TestDriverBase):
     @patch("directord.client.Client.run_threads", autospec=True)
     def test_worker_run(self, mock_run_threads, mock_makedirs):
         self.client.worker_run()
-        mock_run_threads.assert_called_with(ANY, threads=[ANY])
+        mock_run_threads.assert_called_with(ANY, threads=[ANY], stop_event=ANY)
         mock_makedirs.assert_called()

--- a/directord/tests/test_init.py
+++ b/directord/tests/test_init.py
@@ -148,7 +148,11 @@ class TestProcessor(unittest.TestCase):
 
     def test_run_threads(self):
         thread1 = tests.FakeThread()
+        p1 = unittest.mock.patch.object(thread1, "is_alive")
+        p1.side_effect = [True, False]
         thread2 = tests.FakeThread()
+        p2 = unittest.mock.patch.object(thread2, "is_alive")
+        p2.side_effect = [True, False]
         self.processor.run_threads(threads=[(thread1, False), (thread2, True)])
         self.assertFalse(thread1.daemon)
         self.assertTrue(thread2.daemon)

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -368,7 +368,7 @@ class TestServer(tests.TestDriverBase):
         mock_isfile.return_value = True
         m = unittest.mock.mock_open(read_data=b"test data")
         with patch("builtins.open", m):
-            self.server.run_backend(sentinel=True)
+            self.server.run_backend()
         self.mock_driver.backend_send.assert_called()
 
     def test_create_return_jobs(self):
@@ -470,7 +470,7 @@ class TestServer(tests.TestDriverBase):
     def test_run_job(self, mock_log_debug, mock_queue):
         mock_queue.return_value = MagicMock()
         self.server.job_queue = mock_queue
-        self.server.run_job(sentinel=True)
+        self.server.run_job()
 
     @patch("queue.Queue", autospec=True)
     @patch("logging.Logger.debug", autospec=True)
@@ -485,7 +485,7 @@ class TestServer(tests.TestDriverBase):
             }
         ]
         self.server.job_queue = mock_queue
-        self.server.run_job(sentinel=True)
+        self.server.run_job()
 
     @patch("queue.Queue", autospec=True)
     @patch("logging.Logger.critical", autospec=True)
@@ -499,7 +499,7 @@ class TestServer(tests.TestDriverBase):
             }
         ]
         self.server.job_queue = mock_queue
-        self.server.run_job(sentinel=True)
+        self.server.run_job()
 
     @patch("queue.Queue", autospec=True)
     @patch("logging.Logger.debug", autospec=True)
@@ -514,7 +514,7 @@ class TestServer(tests.TestDriverBase):
         ]
         self.server.job_queue = mock_queue
         self.server.workers = {b"test-node1": 12345, b"test-node2": 12345}
-        self.server.run_job(sentinel=True)
+        self.server.run_job()
 
     @patch("time.time", autospec=True)
     def test_run_interactions(self, mock_time):
@@ -543,7 +543,7 @@ class TestServer(tests.TestDriverBase):
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, True, False]
-            self.server.run_interactions(sentinel=True)
+            self.server.run_interactions()
 
     @patch("time.time", autospec=True)
     def test_run_interactions_idle(self, mock_time):
@@ -572,7 +572,7 @@ class TestServer(tests.TestDriverBase):
         mock_time.side_effect = [1, 66, 1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, True, False]
-            self.server.run_interactions(sentinel=True)
+            self.server.run_interactions()
 
     @patch("time.time", autospec=True)
     def test_run_interactions_ramp(self, mock_time):
@@ -601,7 +601,7 @@ class TestServer(tests.TestDriverBase):
         mock_time.side_effect = [1, 34, 1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, True, False]
-            self.server.run_interactions(sentinel=True)
+            self.server.run_interactions()
 
     @patch("time.time", autospec=True)
     def test_run_interactions_run_backend(
@@ -633,7 +633,7 @@ class TestServer(tests.TestDriverBase):
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, True, False]
-            self.server.run_interactions(sentinel=True)
+            self.server.run_interactions()
 
     @patch("directord.server.Server._set_job_status", autospec=True)
     @patch("time.time", autospec=True)
@@ -669,7 +669,7 @@ class TestServer(tests.TestDriverBase):
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, True, False]
-            self.server.run_interactions(sentinel=True)
+            self.server.run_interactions()
         mock_set_job_status.assert_called_with(
             ANY,
             job_status=self.server.driver.transfer_end,
@@ -695,7 +695,7 @@ class TestServer(tests.TestDriverBase):
         conn = MagicMock()
         conn.recv.return_value = json.dumps({}).encode()
         socket.accept.return_value = [conn, MagicMock()]
-        self.server.run_socket_server(sentinel=True)
+        self.server.run_socket_server()
         mock_unlink.assert_called_with(self.args.socket_path)
         mock_chmod.assert_called()
         mock_chown.assert_called()
@@ -720,7 +720,7 @@ class TestServer(tests.TestDriverBase):
             "test-node1": {"time": 12345, "version": "x.x.x"},
             "test-node2": {"time": 12345, "version": "x.x.x"},
         }
-        self.server.run_socket_server(sentinel=True)
+        self.server.run_socket_server()
         mock_unlink.assert_called_with(self.args.socket_path)
         conn.sendall.assert_called_with(
             json.dumps(
@@ -748,7 +748,7 @@ class TestServer(tests.TestDriverBase):
         conn.sendall = MagicMock()
         socket.accept.return_value = [conn, MagicMock()]
         self.server.return_jobs = {"k": {"v": "test"}}
-        self.server.run_socket_server(sentinel=True)
+        self.server.run_socket_server()
         mock_unlink.assert_called_with(self.args.socket_path)
         conn.sendall.assert_called_with(b'[["k", {"v": "test"}]]')
         mock_chmod.assert_called()
@@ -771,7 +771,7 @@ class TestServer(tests.TestDriverBase):
         workers = self.server.workers = datastores.BaseDocument()
         workers[b"test-node1"] = {"version": "x.x.x", "expiry": 12344}
         workers[b"test-node2"] = {"version": "x.x.x", "expiry": 12344}
-        self.server.run_socket_server(sentinel=True)
+        self.server.run_socket_server()
         mock_unlink.assert_called_with(self.args.socket_path)
         self.assertDictEqual(self.server.workers, {})
         conn.sendall.assert_called_with(b'{"success": true}')
@@ -794,7 +794,7 @@ class TestServer(tests.TestDriverBase):
         socket.accept.return_value = [conn, MagicMock()]
         return_jobs = self.server.return_jobs = datastores.BaseDocument()
         return_jobs["k"] = {"v": "test"}
-        self.server.run_socket_server(sentinel=True)
+        self.server.run_socket_server()
         mock_unlink.assert_called_with(self.args.socket_path)
         self.assertDictEqual(self.server.return_jobs, {})
         conn.sendall.assert_called_with(b'{"success": true}')
@@ -822,7 +822,7 @@ class TestServer(tests.TestDriverBase):
         ).encode()
         conn.sendall = MagicMock()
         socket.accept.return_value = [conn, MagicMock()]
-        self.server.run_socket_server(sentinel=True)
+        self.server.run_socket_server()
         mock_unlink.assert_called_with(self.args.socket_path)
         self.assertDictEqual(self.server.return_jobs, {})
         conn.sendall.assert_called_with(b"Job received. Task ID: XXX")
@@ -850,7 +850,7 @@ class TestServer(tests.TestDriverBase):
         ).encode()
         conn.sendall = MagicMock()
         socket.accept.return_value = [conn, MagicMock()]
-        self.server.run_socket_server(sentinel=True)
+        self.server.run_socket_server()
         mock_unlink.assert_called_with(self.args.socket_path)
         self.assertDictEqual(self.server.return_jobs, {})
         conn.sendall.assert_called_with(b"XXX")
@@ -863,4 +863,6 @@ class TestServer(tests.TestDriverBase):
             self.server.worker_run()
         finally:
             self.args = tests.FakeArgs()
-        mock_run_threads.assert_called_with(ANY, threads=[ANY, ANY, ANY])
+        mock_run_threads.assert_called_with(
+            ANY, threads=[ANY, ANY, ANY], stop_event=ANY
+        )


### PR DESCRIPTION
This change implements a handler for thread exceptions which will
reraise on join allowing the application to shutdown gracefully when
exceptions are encountered.

Signed-off-by: Kevin Carter <kecarter@redhat.com>