### PR TITLE
Increase file limits for the server

### DIFF
--- a/directord/templates/directord-server.service.j2
+++ b/directord/templates/directord-server.service.j2
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 User=root
 Group={{ directord_group }}
+LimitNOFILE=65536
 ExecStart={{ directord_binary }} --config-file /etc/directord/config.yaml --socket-group {{ directord_group }} server
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
For grpc with ssl, this is necessary as the number of sockets is more
than the default limits because multiple connections are created by the
clients.

Signed-off-by: Alex Schultz <aschultz@redhat.com>