### PR TITLE
Add durable queue type option for clients

### DIFF
--- a/.github/workflows/pull-request-functional.yml
+++ b/.github/workflows/pull-request-functional.yml
@@ -276,6 +276,57 @@ jobs:
           name: functional-redis-test-logs
           path: /tmp/directord-*.log
 
+  functional_durable_queue_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+      - name: Run install
+        run: sudo bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
+      - name: Configure durable queues
+        run: >-
+          echo 'durable_queue_enabled: true' | sudo tee -a /etc/directord/config.yaml
+      - name: Run server service install
+        run: |
+          sudo /opt/directord/bin/directord-server-systemd
+          sudo systemctl daemon-reload
+          sudo systemctl restart directord-server
+      - name: Run client service install
+        run: |
+          sudo /opt/directord/bin/directord-client-systemd
+          sudo systemctl daemon-reload
+          sudo systemctl restart directord-client
+      - name: Wait for client online
+        run: |
+          timeout 120 bash -c 'while ! sudo /opt/directord/bin/directord manage --list-nodes; do sleep 1; done'
+      - name: Execute functional check
+        run: |
+          cd /opt/directord/share/directord/orchestrations
+          sudo timeout 240 /opt/directord/bin/directord \
+                                              orchestrate \
+                                              functional-tests.yaml \
+                                              --poll \
+                                              --check
+      - name: Generate log details
+        run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+        if: failure()
+      - name: Upload build Log artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-durable-queue-test-logs
+          path: /tmp/directord-*.log
+
   functional_defaults_query_check:
     runs-on: ubuntu-latest
     steps:

--- a/directord/drivers/zmq.py
+++ b/directord/drivers/zmq.py
@@ -115,6 +115,7 @@ class Driver(drivers.BaseDriver):
 
         self.thread_processor = multiprocessing.Process
         self.event = multiprocessing.Event()
+        self.condition = multiprocessing.Condition
         self.args = args
         self.encrypted_traffic_data = encrypted_traffic_data
 
@@ -708,11 +709,25 @@ class Driver(drivers.BaseDriver):
 
         return multiprocessing.Lock()
 
-    @staticmethod
-    def get_queue():
-        """Returns a thread lock."""
+    def get_queue(self, path=None):
+        """Returns a queue object.
 
-        return multiprocessing.Queue()
+        If the path is defined, a durable queue object will be returned.
+
+        :param path: Path store all queue items.
+        :type path: String.
+        """
+
+        if path and self.durable_queue_enabled is True:
+            return utils.DurableQueue(
+                maxsize=0,
+                mutex=self.get_lock(),
+                lock=self.get_lock(),
+                condition=self.condition,
+                path=path,
+            )
+        else:
+            return multiprocessing.Queue()
 
     def key_generate(self, keys_dir, key_type):
         """Generate certificate.

--- a/directord/main.py
+++ b/directord/main.py
@@ -18,6 +18,8 @@ import os
 import pkgutil
 import sys
 
+from distutils.util import strtobool
+
 import jinja2
 from jinja2 import StrictUndefined
 
@@ -127,7 +129,7 @@ def _args(exec_args=None):
     parser.add_argument(
         "--debug",
         help="Enable debug mode. Default: %(default)s",
-        default=os.getenv("DIRECTORD_DEBUG", False),
+        default=bool(strtobool(os.getenv("DIRECTORD_DEBUG", "False"))),
         action="store_true",
     )
     server_group = parser.add_argument_group("Server options")
@@ -210,6 +212,14 @@ def _args(exec_args=None):
         metavar="STRING",
         default=os.getenv("DIRECTORD_MACHINE_ID", None),
         type=str,
+    )
+    parser_client.add_argument(
+        "--durable-queue-enabled",
+        help="Enable client side durable queues: %(default)s",
+        default=bool(
+            strtobool(os.getenv("DIRECTORD_DURABLE_QUEUE_ENABLED", "False"))
+        ),
+        action="store_true",
     )
     parser_orchestrate = subparsers.add_parser(
         "orchestrate", help="Orchestration mode help"

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -12,12 +12,11 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
+import queue
 import unittest
 
 from unittest.mock import MagicMock
 from unittest.mock import patch
-
-from collections import namedtuple
 
 from directord import drivers
 from directord.drivers import messaging
@@ -250,10 +249,15 @@ class TestDriverBase(unittest.TestCase):
         self.zmq = zmq.Driver
         self.messaging = messaging.Driver
         base_driver = drivers.BaseDriver(args=FakeArgs())
+        self.patched_get_queue = patch(
+            "directord.utils.DurableQueue", autospec=True
+        )
         self.mock_driver_patched = patch(
             "directord.drivers.BaseDriver",
             autospec=True,
         )
+        self.mocked_get_queue = self.patched_get_queue.start()
+        self.mocked_get_queue.return_value = queue.Queue()
         self.mock_driver = self.mock_driver_patched.start()
         self.mock_driver.job_check.return_value = True
         self.mock_driver.nullbyte = base_driver.nullbyte
@@ -276,3 +280,4 @@ class TestDriverBase(unittest.TestCase):
 
     def tearDown(self):
         self.mock_driver_patched.stop()
+        self.patched_get_queue.stop()

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -39,10 +39,14 @@ from directord.components.lib.podman import PodmanClient
 class TestComponents(unittest.TestCase):
     def setUp(self):
         self.args = tests.FakeArgs()
+        self.patched_get_queue = patch(
+            "directord.utils.DurableQueue", autospec=True
+        )
+        self.patched_get_queue.start()
         self.client = client.Client(args=self.args)
-
         self.mock_q_patched = patch("queue.Queue", autospec=True)
         q = self.mock_q_patched.start()
+        self.patched_get_queue.return_value = q
         self.client.q_processes = q
         self.client.q_return = q
 
@@ -73,6 +77,7 @@ class TestComponents(unittest.TestCase):
             item.driver = drivers.BaseDriver(args=self.args)
 
     def tearDown(self):
+        self.patched_get_queue.stop()
         self.mock_q_patched.stop()
 
     def test_options_converter(self):

--- a/directord/tests/test_datastore_disc.py
+++ b/directord/tests/test_datastore_disc.py
@@ -66,4 +66,5 @@ class TestDatastoreDisc(unittest.TestCase):
 
     def test_set(self):
         with patch("builtins.open", unittest.mock.mock_open()):
-            self.datastore.set(key="key", value="value")
+            with patch("pickle.load", autospec=True):
+                self.datastore.set(key="key", value="value")

--- a/directord/tests/test_main.py
+++ b/directord/tests/test_main.py
@@ -357,6 +357,7 @@ class TestMain(unittest.TestCase):
                 "driver": "zmq",
                 "job_port": 5555,
                 "backend_port": 5556,
+                "durable_queue_enabled": False,
                 "heartbeat_interval": 60,
                 "identity": None,
                 "socket_group": "0",

--- a/directord/utils.py
+++ b/directord/utils.py
@@ -15,7 +15,9 @@
 import hashlib
 import json
 import os
+import pickle
 import pkgutil
+import queue
 import socket
 import struct
 import sys
@@ -443,11 +445,13 @@ class Cache:
 
         with Locker(lock=self.lock):
             try:
-                with open(os.path.join(self.db_path, self.encoder(key))) as f:
-                    data = f.read()
+                with open(
+                    os.path.join(self.db_path, self.encoder(key)), "rb"
+                ) as f:
+                    data = pickle.load(f)
                     try:
                         return json.loads(data)
-                    except json.decoder.JSONDecodeError:
+                    except Exception:
                         return data
             except FileNotFoundError:
                 return
@@ -479,8 +483,8 @@ class Cache:
 
         file_object = os.path.join(self.db_path, self.encoder(key))
         with Locker(lock=self.lock):
-            with open(file_object, "w") as f:
-                f.write(value)
+            with open(file_object, "wb") as f:
+                pickle.dump(value, f)
             try:
                 try:
                     os.getxattr(file_object, "user.birthtime")
@@ -608,3 +612,38 @@ class Cache:
 
         for item in self.keys():
             self.__delitem__(key=item)
+
+
+class DurableQueue(queue.Queue):
+    """Durable queue class, used to ensure queued items are disk backed."""
+
+    def __init__(self, maxsize, mutex, lock, condition, path):
+        self.maxsize = maxsize
+        self.mutex = mutex
+        self.not_empty = condition(self.mutex)
+        self.not_full = condition(self.mutex)
+        self.all_tasks_done = condition(self.mutex)
+        self.path = path
+        self.queue = Cache(url=self.path, lock=lock)
+        self.unfinished_tasks = self._qsize()
+
+    def _init(self, *args, **kwargs):
+        pass
+
+    def _qsize(self):
+        """Return the queue size."""
+        return len(list(self.queue.keys()))
+
+    def _put(self, item):
+        """Put a new item within the queue."""
+        self.queue[get_uuid()] = item
+
+    def _get(self):
+        """Retrieve the first item from the queue."""
+        for item in self.queue.keys():
+            return self.queue.pop(item)
+
+    def close(self):
+        """Close the current Queue and cleanup artifacts."""
+        self.queue.clear()
+        os.rmdir(self.path)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -76,6 +76,22 @@ unless otherwise configured differently. Cached [ARGS](components.md#arg)
 are stored indefinitely but can be [EVICTED](components.md#cacheevict)
 through client interactions as needed.
 
+#### Client Durability
+
+Clients can also use durable queues, which will ensure that task operations
+are disk backed, making it possible for the client to automatically recover
+operations in the event of a crash. While durable queues are a production
+focused feature, enabling it comes with certain performance penalties due to
+queue operations running on the local file-system instead of within memory.
+However, given the performance of modern storage media, the impact to
+client task performance should be minor, and in most cases it will go
+unnoticed.
+
+* Set the environment variable `DIRECTORD_DURABLE_QUEUE_ENABLED` to **True**,
+  define the option `durable_queue_enabled: true` in config,  or use the CLI
+  switch `--durable-queue-enabled` to enable the client-side durable queue
+  feature.
+
 #### Profiling
 
 Every Directord task is profiled. The execution and the round trip time are


### PR DESCRIPTION
With the durable queue option, clients can recover tasks and
other operations should the client ever crash. This option has been
added to the application main as both an environment variable and CLI
switch.

Signed-off-by: Kevin Carter <kecarter@redhat.com>