### PR TITLE
Add exception handling to client execution

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -384,9 +384,19 @@ class Client(interface.Interface):
                 self.log.debug("Lock acquired for [ %s ]", job_id)
 
             _starttime = time.time()
-            stdout, stderr, outcome, info = component.client(
-                cache=self.cache, job=job
-            )
+            try:
+                stdout, stderr, outcome, info = component.client(
+                    cache=self.cache, job=job
+                )
+            except Exception as e:
+                stderr = "Job [ {} ] Component Failure: {}".format(
+                    job_id, str(e)
+                )
+                self.log.critical(stderr)
+                stdout = None
+                outcome = False
+                info = e.__traceback__
+
             job["component_exec_timestamp"] = datetime.datetime.fromtimestamp(
                 time.time()
             ).strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
the client side execution handler will now try / except and in the event
of an error it will return back information to the user showing what
failed and where.

Signed-off-by: Kevin Carter <kecarter@redhat.com>