### PR TITLE
Skip client close on job close

### DIFF
--- a/directord/drivers/grpcd.py
+++ b/directord/drivers/grpcd.py
@@ -1208,12 +1208,10 @@ class Driver(drivers.BaseDriver):
 
     def job_close(self):
         """Close the job socket."""
-        if self.mode == "server" and self._server:
-            self._server.stop()
-        if self._client:
-            self._client.close()
-        self._server = None
-        self._client = None
+        self.log.debug(
+            "The grpcd driver shares a single client between all threads, "
+            "skipping close."
+        )
 
     def job_check(self, interval=1, constant=1000):
         """Return True if a job contains work ready.


### PR DESCRIPTION
Since we switched to a single client shared between all threads, we
don't want to close the client with the driver's job_close function.

Fixes #338