### PR TITLE
Add grpc scripts to packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,5 +118,13 @@ setuptools.setup(
                 if os.path.isfile(i)
             ],
         ),
+        (
+            "share/directord/tools/scripts/grpcd",
+            [
+                i
+                for i in glob.glob("tools/scripts/grpcd/*")
+                if os.path.isfile(i)
+            ],
+        ),
     ],
 )


### PR DESCRIPTION
Need to make sure to grab the grpcd setup scripts for installation.

Signed-off-by: Alex Schultz <aschultz@redhat.com>