### PR TITLE
Fix query information part

### DIFF
--- a/directord/components/builtin_query.py
+++ b/directord/components/builtin_query.py
@@ -111,9 +111,4 @@ class Component(components.ComponentBase):
                 )
                 self.block_on_tasks = [wait_job]
 
-        return (
-            json.dumps({job["query"]: query}),
-            None,
-            True,
-            query,
-        )
+        return (json.dumps({job["query"]: query}), None, True, job["query"])


### PR DESCRIPTION
When query is not string, but different datatype, it can't be sent
as is, causing socker_send failure.
Send not the query value, but only key in query information part.