### PR TITLE
Replace the cache class with iodict

### DIFF
--- a/contrib/container-build/Containerfile
+++ b/contrib/container-build/Containerfile
@@ -25,7 +25,7 @@ RUN dnf -y update && \
     echo '%builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # TODO(cloudnull): remove all this when ssh-python is packaged
-RUN dnf -y install rpmdevtools python3-pytoml python3-pyxdg python38-requests cmake openssl openssl-devel python3-devel && \
+RUN dnf -y install rpmdevtools python3-pytoml python3-pyxdg python38-requests cmake openssl openssl-devel python3-devel wget && \
     dnf -y groupinstall 'Development Tools' && \
     python3 -m venv /home/builder/pyp2rpm --system-site-packages && \
     /home/builder/pyp2rpm/bin/pip install pyp2rpm && \

--- a/contrib/container-build/builder.sh
+++ b/contrib/container-build/builder.sh
@@ -11,6 +11,13 @@ sudo chown builder: /home/builder/rpm
 echo "Creating artifact directory: ${ARTIFACT_DIR}"
 mkdir -p ${ARTIFACT_PATH}
 
+# Remove when iodict is actually packaged.
+IODICTRELEASE=$(curl --silent 'https://api.github.com/repos/directord/iodict/releases/latest' | grep '"tag_name":' |  sed -E 's/.*"([^"]+)".*/\1/')
+pushd ${ARTIFACT_PATH}
+  wget "https://github.com/directord/iodict/releases/download/${IODICTRELEASE}/iodict-${IODICTRELEASE}-1.el8.noarch.rpm"
+  sudo dnf -y install iodict-${IODICTRELEASE}-1.el8.noarch.rpm
+popd
+
 echo "Installing build deps..."
 echo "Logging to ${ARTIFACT_PATH}/builddep.log"
 sudo dnf -y builddep "${SPEC_PATH}" &> ${ARTIFACT_PATH}/builddep.log

--- a/contrib/container-build/directord.spec
+++ b/contrib/container-build/directord.spec
@@ -31,6 +31,9 @@ Requires:       python3-pyyaml
 Requires:       python3-tabulate
 Requires:       python3-tenacity
 
+# TODO(cloudnull): Change this to an actual package when it exists.
+Requires:       python3dist(iodict)
+
 # Recommends
 Recommends:       python3-ssh-python
 Recommends:       python3-zmq

--- a/directord/tests/test_datastore_disc.py
+++ b/directord/tests/test_datastore_disc.py
@@ -12,6 +12,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
+import pickle
 import unittest
 from unittest.mock import patch
 
@@ -37,34 +38,13 @@ class TestDatastoreDisc(tests.TestBase):
         self.chdir_patched.stop()
         self.setxattr_patched.stop()
 
-    def test___getitem__string(self):
-        self.datastore.__getitem__(key="test")
-
-    def test___setitem__(self):
-        with patch("builtins.open", unittest.mock.mock_open()):
-            self.datastore.__setitem__(key="key", value="value")
-
-    def test___delitem__(self):
-        self.datastore.__delitem__(key="key")
-
-    def test_items(self):
-        self.datastore.items()
-
-    def test_keys(self):
-        self.datastore.keys()
-
-    def test_empty(self):
-        self.datastore.empty()
-
-    def test_pop(self):
-        self.datastore.pop(key="key")
-
     def test_prune(self):
         self.datastore.prune()
 
-    def test_get(self):
-        self.datastore.get(key="key")
-
     def test_set(self):
-        with patch("builtins.open", unittest.mock.mock_open()):
-            self.datastore.set(key="key", value="value")
+        read_data = pickle.dumps("value")
+        with patch(
+            "builtins.open", unittest.mock.mock_open(read_data=read_data)
+        ):
+            value = self.datastore.set(key="key", value="value")
+            self.assertAlmostEqual(value, "value")

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setuptools.setup(
         "ssh-python",
         "tabulate",
         "tenacity",
+        "iodict",
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tools/prod-setup.sh
+++ b/tools/prod-setup.sh
@@ -64,7 +64,8 @@ if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]] || [[ ${ID} == "fedora" ]]; 
     wget https://github.com/directord/directord/releases/download/${RELEASE}/rpm-bundle.tar.gz
     tar xf rpm-bundle.tar.gz
     RPMS=$(ls -1 *.rpm | egrep -v '(debug|src)')
-    dnf -y install ${RPMS}
+    IODICTRELEASE="$(get_latest_release directord/iodict)"
+    dnf -y install ${RPMS} https://github.com/directord/directord/releases/download/${IODICTRELEASE}/iodict-${IODICTRELEASE}-1.el8.noarch.rpm
   popd
   echo -e "\nDirectord is setup and installed within [ /usr/bin ]"
   echo "Activate the venv or run directord directly."


### PR DESCRIPTION
IODict is a library developed under the directord organization and
serves as a replacement for the current Cache class. While the Cache
class and IODict are similar, IODict implements the whole python dict
API, and provides 100% test coverage.

IODict is a new dependency, from within the Directord organization. This
will require additional packaging efforts, but will provide a cleaner
code base within directord and serve as a starting point to close the
durable queue efforts related to issue #343.

Signed-off-by: Kevin Carter <kevin@cloudnull.com>