### PR TITLE
DurableQueue

### DIFF
--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -290,9 +290,9 @@ class ComponentBase:
             orig = cache.get(key, default=dict())
             value = utils.merge_dict(orig, value, extend=extend)
 
-        cache_set = cache.set(key, value)
+        cache_set = cache.setdefault(key, value)
         if not cache_set:
-            return cache.set(key, value)
+            return cache.setdefault(key, value)
         return cache_set
 
     def file_blueprinter(self, cache, file_to):

--- a/directord/components/builtin_cacheevict.py
+++ b/directord/components/builtin_cacheevict.py
@@ -77,7 +77,11 @@ class Component(components.ComponentBase):
             evicted = cache.clear()
             info = "All cache has been cleared"
         else:
-            evicted = cache.evict(tag)
-            info = "Evicted {} items, tagged {}".format(evicted, tag)
+            try:
+                evicted = cache.pop(tag)
+            except KeyError as e:
+                return None, str(e), False, None
+            else:
+                info = "Evicted {} items, tagged {}".format(evicted, tag)
 
         return info, None, True, None

--- a/directord/datastores/__init__.py
+++ b/directord/datastores/__init__.py
@@ -18,20 +18,6 @@ import time
 class BaseDocument(dict):
     """Create a document store object."""
 
-    def empty(self):
-        """Empty all items from the datastore.
-
-        Because a Manager Dict is a proxy object we don't want to replace the
-        object we want to empty it keeping the original proxy intact. This
-        method will pop all items from the object.
-        """
-
-        try:
-            while self.popitem():
-                pass
-        except KeyError:
-            pass
-
     def prune(self):
         """Prune items that have a time based expiry."""
 

--- a/directord/datastores/disc.py
+++ b/directord/datastores/disc.py
@@ -22,6 +22,9 @@ from directord import utils
 class BaseDocument(utils.Cache):
     """Create a document store object."""
 
+    def __init__(self, url):
+        super().__init__(path=os.path.abspath(os.path.expanduser(url)))
+
     def __setitem__(self, key, value):
         """Set an item in the datastore.
 
@@ -51,11 +54,6 @@ class BaseDocument(utils.Cache):
                 )
             except OSError:
                 pass
-
-    def empty(self):
-        """Remove all cache."""
-
-        self.clear()
 
     def prune(self):
         """Prune items that have a time based expiry."""

--- a/directord/datastores/memory.py
+++ b/directord/datastores/memory.py
@@ -29,7 +29,6 @@ BaseDictProxy = MakeProxyType(
         "__setitem__",
         "clear",
         "copy",
-        "empty",
         "get",
         "items",
         "keys",

--- a/directord/datastores/redis.py
+++ b/directord/datastores/redis.py
@@ -104,7 +104,7 @@ class BaseDocument:
 
         return [i.decode() for i in self.datastore.keys("*")]
 
-    def empty(self):
+    def clear(self):
         """Empty all items from the datastore.
 
         Because a Manager Dict is a proxy object we don't want to replace the

--- a/directord/tests/test_client.py
+++ b/directord/tests/test_client.py
@@ -219,7 +219,7 @@ class TestClient(tests.TestDriverBase):
             )
         ]
         cache = mock_diskcache.return_value = tests.FakeCache()
-        cache.set(key="ZZZ", value=False)
+        cache.setdefault(key="ZZZ", value=False)
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]
@@ -251,7 +251,7 @@ class TestClient(tests.TestDriverBase):
             )
         ]
         cache = mock_diskcache.return_value = tests.FakeCache()
-        cache.set(key="YYY", value=self.mock_driver.job_end)
+        cache.setdefault(key="YYY", value=self.mock_driver.job_end)
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.client, "cache", cache):
             with patch.object(self.mock_driver, "job_check") as mock_job_check:
@@ -285,7 +285,7 @@ class TestClient(tests.TestDriverBase):
             )
         ]
         cache = mock_diskcache.return_value = tests.FakeCache()
-        cache.set(key="YYY", value=self.mock_driver.job_end)
+        cache.setdefault(key="YYY", value=self.mock_driver.job_end)
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.client, "cache", cache):
             with patch.object(self.mock_driver, "job_check") as mock_job_check:
@@ -319,7 +319,7 @@ class TestClient(tests.TestDriverBase):
             )
         ]
         cache = mock_diskcache.return_value = tests.FakeCache()
-        cache.set(key="YYY", value=self.mock_driver.job_failed)
+        cache.setdefault(key="YYY", value=self.mock_driver.job_failed)
         mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1]
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -43,11 +43,13 @@ class TestComponents(tests.TestBase):
         with patch("directord.plugin_import", autospec=True):
             self.client = client.Client(args=self.args)
 
-        self.mock_q_patched = patch("queue.Queue", autospec=True)
-        q = self.mock_q_patched.start()
-        self.client.q_processes = q
-        self.client.q_return = q
-
+        self.patched_get_queue = patch(
+            "directord.utils.DurableQueue", autospec=True
+        )
+        self.patched_get_queue.start()
+        self.patched_get_queue.return_value = tests.FakeQueue()
+        self.client.q_processes = tests.FakeQueue()
+        self.client.q_return = tests.FakeQueue()
         self.fake_cache = tests.FakeCache()
         self.components = components.ComponentBase(desc="test")
         self.execute = ["long '{{ jinja }}' quoted string", "string"]
@@ -76,7 +78,7 @@ class TestComponents(tests.TestBase):
 
     def tearDown(self):
         super().tearDown()
-        self.mock_q_patched.stop()
+        self.patched_get_queue.stop()
 
     def test_options_converter(self):
         self.components.args()

--- a/directord/tests/test_datastore_internal.py
+++ b/directord/tests/test_datastore_internal.py
@@ -25,7 +25,7 @@ class TestDatastoreInternal(tests.TestBase):
     def test_wq_prune_0(self):
         workers = datastores.BaseDocument()
         workers["test"] = 1
-        workers.empty()
+        workers.clear()
         self.assertDictEqual(workers, dict())
 
     def test_wq_prune_valid(self):
@@ -37,11 +37,11 @@ class TestDatastoreInternal(tests.TestBase):
         self.assertEqual(len(workers), 1)
         self.assertIn("valid1", workers)
 
-    def test_wq_empty(self):
+    def test_wq_clear(self):
         workers = datastores.BaseDocument()
         workers["valid1"] = {"time": time.time() + 2}
         workers["invalid1"] = {"time": time.time() - 2}
         workers["invalid2"] = {"time": time.time() - 3}
         self.assertEqual(len(workers), 3)
-        workers.empty()
+        workers.clear()
         self.assertEqual(len(workers), 0)

--- a/directord/tests/test_datastore_redis.py
+++ b/directord/tests/test_datastore_redis.py
@@ -12,7 +12,6 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-import unittest
 from unittest.mock import patch
 
 import redis
@@ -53,7 +52,7 @@ class TestDatastoreRedis(tests.TestBase):
         self.datastore.keys()
 
     def test_empty(self):
-        self.datastore.empty()
+        self.datastore.clear()
 
     def test_pop(self):
         self.datastore.pop(key="key")

--- a/directord/tests/test_drivers_messaging.py
+++ b/directord/tests/test_drivers_messaging.py
@@ -43,11 +43,6 @@ class TestDriverMessaging(tests.TestBase):
             self.driver.get_lock()
             mock_lock.assert_called()
 
-    def test_get_queue(self):
-        with patch("queue.Queue") as mock_queue:
-            self.driver.get_queue()
-            mock_queue.assert_called()
-
     @patch("directord.utils.get_uuid", autospec=True)
     @patch("directord.drivers.messaging.Driver._send")
     def test_heartbeat_send(self, mock_send, mock_get_uuid):

--- a/directord/tests/test_drivers_zmq.py
+++ b/directord/tests/test_drivers_zmq.py
@@ -42,11 +42,6 @@ class TestDriverZMQSharedAuth(tests.TestBase):
             self.driver.get_lock()
             mock_lock.assert_called()
 
-    def test_get_queue(self):
-        with patch("multiprocessing.Queue") as mock_queue:
-            self.driver.get_queue()
-            mock_queue.assert_called()
-
     def test_socket_connect_curve_auth(self):
         m = unittest.mock.mock_open(read_data=tests.MOCK_CURVE_KEY.encode())
         with patch("builtins.open", m):

--- a/directord/tests/test_init.py
+++ b/directord/tests/test_init.py
@@ -22,7 +22,6 @@ import directord
 
 from directord import logger
 from directord import tests
-from directord import user
 
 
 COMPONENT_FAILURE_INFO = """Failure - Unknown Component

--- a/directord/tests/test_user.py
+++ b/directord/tests/test_user.py
@@ -159,7 +159,7 @@ class TestManager(tests.TestDriverBase):
     @patch("directord.utils.Cache", autospec=True)
     def test_run_override_dump_cache(self, mock_diskcache, mock_print):
         cache = mock_diskcache.return_value = tests.FakeCache()
-        cache.set(key="test", value="value")
+        cache.setdefault(key="test", value="value")
         self.manage.run(override="dump-cache")
         mock_print.assert_called_with(
             '{\n    "args": {\n        "test": 1\n    },\n    "test": "value"\n}'  # noqa

--- a/directord/user.py
+++ b/directord/user.py
@@ -297,10 +297,10 @@ class Manage(User):
 
         def _cache_dump():
             try:
-                with utils.Cache(
-                    url=os.path.join(self.args.cache_path, "client")
-                ) as cache:
-                    print(json.dumps(dict(cache.items()), indent=4))
+                cache = utils.Cache(
+                    path=os.path.join(self.args.cache_path, "client")
+                )
+                print(json.dumps(dict(cache.items()), indent=4))
             except KeyError:
                 pass
 


### PR DESCRIPTION
Replace volatile client and server queue types

The volatile queue types for both client and server have replaced with a
durable queue. The durable queue class is now part of utils, and builds
upon our existing cache class. When Directord is shutdown, items in
queue will now be flushed to disk and restored as needed. This works on
both the server and client giving directord durability across shutdowns.

* When a shutdown is started, directord will flush all pending operations
  to disk, finish inflight operations, and cleanly stop. Upon restart,
  directord will look for on-disk queues and continue working on anything
  discovered.

Closes #343
Signed-off-by: Kevin Carter <kevin@cloudnull.com>
