### PR TITLE
Add --reloaded to service component

### DIFF
--- a/directord/components/builtin_service.py
+++ b/directord/components/builtin_service.py
@@ -32,6 +32,11 @@ class Component(components.ComponentBase):
         super().args()
         running_group = self.parser.add_mutually_exclusive_group()
         running_group.add_argument(
+            "--reloaded",
+            action="store_true",
+            help="Ensure service is reloaded",
+        )
+        running_group.add_argument(
             "--restarted",
             action="store_true",
             help="Ensure service is restarted",
@@ -83,10 +88,12 @@ class Component(components.ComponentBase):
         elif self.known_args.disable:
             data["state"] = "disable"
 
-        elif self.known_args.restarted:
+        if self.known_args.restarted:
             data["running"] = "restart"
         elif self.known_args.stopped:
             data["running"] = "stop"
+        elif self.known_args.reloaded:
+            data["running"] = "reload"
         else:
             data["running"] = "start"
 

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -458,6 +458,19 @@ class TestComponents(unittest.TestCase):
         self.assertTrue(outcome)
         self.assertEqual(mock_run_command.call_args_list, calls)
 
+    @patch("directord.components.ComponentBase.run_command", autospec=True)
+    def test__service_command_reload_success(self, mock_run_command):
+        mock_run_command.return_value = [b"", b"", True]
+        stdout, stderr, outcome, return_info = self._service.client(
+            cache=tests.FakeCache(),
+            job={"services": ["httpd.service"], "running": "reload"},
+        )
+        calls = [
+            call(command="systemctl reload httpd.service", env=None),
+        ]
+        self.assertTrue(outcome)
+        self.assertEqual(mock_run_command.call_args_list, calls)
+
     @patch("subprocess.Popen")
     def test_run_command_success(self, popen):
         popen.return_value = tests.FakePopen()

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -281,6 +281,7 @@ Syntax: `SERVICE [SERVICE ...]`
 
 > Manage systemd service state
 
+* `--reloaded ` **BOOLEAN** Ensure service is reloaded.
 * `--restarted` **BOOLEAN** Ensure service is restarted.
 * `--stopped` **BOOLEAN** Ensure service is stopped.
 * `--enable` **BOOLEAN** Ensure service is enabled.


### PR DESCRIPTION
We may want to reload a service rather than start/restart/stop.  This
change adds --reloaded to the service component to be able to trigger a
reload.  This change also fixes the logic around state/running.

Signed-off-by: Alex Schultz <aschultz@redhat.com>