### PR TITLE
use pre-fork signals to allow exit

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -44,6 +44,14 @@ class Client(interface.Interface):
         self.cache = dict()
         self.start_time = time.time()
 
+    def exit_gracefully(self, *args, **kwargs):
+        """Set the driver event to begin the shutdown of the application."""
+
+        self.log.warning(
+            "Shutdown signal intercepted. Starting client shutdown."
+        )
+        self.driver.event.set()
+
     def q_processor(self, queue, lock):
         """Process jobs from the known queue.
 


### PR DESCRIPTION
This change will allow directord to attempt a graceful shutdown of the
application. Because signals can not be used in multi-threading, all
of the signal processing is handled pre-fork|thread. The server|client
classes then use the driver event handler to begin a system shutdown
when a signal is encountered.

Signed-off-by: Kevin Carter <kevin@cloudnull.com>