### PR TITLE
Cleanup tests to remove the crazy output

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -855,3 +855,5 @@ class Client(interface.Interface):
         ) as cache:
             self.cache = cache
             self.run_threads(threads=threads, stop_event=self.driver.event)
+
+        self.driver.shutdown()

--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -88,6 +88,11 @@ class BaseDriver:
 
         self.interface = interface
 
+    def shutdown(self):
+        """Shutdown the driver."""
+
+        pass
+
     @staticmethod
     def get_lock():
         """Returns a thread lock."""

--- a/directord/drivers/dummy.py
+++ b/directord/drivers/dummy.py
@@ -12,21 +12,25 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-from unittest.mock import patch
-
-from directord import interface
-from directord import tests
+from directord import drivers
 
 
-class TestInterface(tests.TestBase):
-    def setUp(self):
-        super().setUp()
-        self.args = tests.FakeArgs()
+def parse_args(parser, parser_server, parser_client):
+    """Add arguments for this driver to the parser.
 
-    def test_interface_no_driver(self):
-        with patch(
-            "directord.plugin_import", autospec=True
-        ) as mock_plugin_import:
-            mock_plugin_import.side_effect = ImportError("fail")
-            with self.assertRaises(SystemExit):
-                interface.Interface(args=self.args)
+    :param parser: Parser
+    :type parser: Object
+    :param parser_server: SubParser object
+    :type parser_server: Object
+    :param parser_client: SubParser object
+    :type parser_client: Object
+    :returns: Object
+    """
+
+    return parser
+
+
+class Driver(drivers.BaseDriver):
+    """Dummy driver implements the base class and nothing else."""
+
+    pass

--- a/directord/server.py
+++ b/directord/server.py
@@ -1016,3 +1016,4 @@ class Server(interface.Interface):
         ]
 
         self.run_threads(threads=threads, stop_event=self.driver.event)
+        self.driver.shutdown()

--- a/directord/tests/test_client.py
+++ b/directord/tests/test_client.py
@@ -23,9 +23,10 @@ from directord import tests
 
 class TestClient(tests.TestDriverBase):
     def setUp(self):
-        super(TestClient, self).setUp()
+        super().setUp()
         self.args = tests.FakeArgs()
-        self.client = client.Client(args=self.args)
+        with patch("directord.plugin_import", autospec=True):
+            self.client = client.Client(args=self.args)
         self.client.driver = self.mock_driver
 
     @patch("time.time", autospec=True)
@@ -131,12 +132,10 @@ class TestClient(tests.TestDriverBase):
             self.client.run_job()
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_skip_skip_cache_run(
         self,
         mock_time,
-        mock_log_info,
         mock_diskcache,
     ):
         job_def = {
@@ -162,15 +161,12 @@ class TestClient(tests.TestDriverBase):
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]
             self.client.run_job()
-        mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_skip_ignore_cache_run(
         self,
         mock_time,
-        mock_log_info,
         mock_diskcache,
     ):
         job_def = {
@@ -197,15 +193,12 @@ class TestClient(tests.TestDriverBase):
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]
             self.client.run_job()
-        mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_parent_failed_run(
         self,
         mock_time,
-        mock_log_info,
         mock_diskcache,
     ):
         job_def = {
@@ -231,15 +224,12 @@ class TestClient(tests.TestDriverBase):
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]
             self.client.run_job()
-        mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_cache_hit_run(
         self,
         mock_time,
-        mock_log_info,
         mock_diskcache,
     ):
         job_def = {
@@ -267,15 +257,12 @@ class TestClient(tests.TestDriverBase):
             with patch.object(self.mock_driver, "job_check") as mock_job_check:
                 mock_job_check.side_effect = [True, False]
                 self.client.run_job()
-        mock_log_info.assert_called()
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_run(
         self,
         mock_time,
-        mock_log_info,
         mock_diskcache,
     ):
         job_def = {
@@ -304,16 +291,13 @@ class TestClient(tests.TestDriverBase):
             with patch.object(self.mock_driver, "job_check") as mock_job_check:
                 mock_job_check.side_effect = [True, False]
                 self.client.run_job()
-        mock_log_info.assert_called()
         self.assertEqual(cache.get("YYY"), self.mock_driver.job_end)
 
     @patch("shelve.open", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     @patch("time.time", autospec=True)
     def test_run_job_run_outcome_false(
         self,
         mock_time,
-        mock_log_info,
         mock_diskcache,
     ):
         job_def = {
@@ -340,7 +324,6 @@ class TestClient(tests.TestDriverBase):
         with patch.object(self.mock_driver, "job_check") as mock_job_check:
             mock_job_check.side_effect = [True, False]
             self.client.run_job()
-        mock_log_info.assert_called()
         self.assertEqual(cache.get("YYY"), self.mock_driver.job_failed)
 
     @patch("os.makedirs", autospec=True)

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -36,10 +36,12 @@ from directord.components.lib.podman import PodmanImage
 from directord.components.lib.podman import PodmanClient
 
 
-class TestComponents(unittest.TestCase):
+class TestComponents(tests.TestBase):
     def setUp(self):
+        super().setUp()
         self.args = tests.FakeArgs()
-        self.client = client.Client(args=self.args)
+        with patch("directord.plugin_import", autospec=True):
+            self.client = client.Client(args=self.args)
 
         self.mock_q_patched = patch("queue.Queue", autospec=True)
         q = self.mock_q_patched.start()
@@ -73,6 +75,7 @@ class TestComponents(unittest.TestCase):
             item.driver = drivers.BaseDriver(args=self.args)
 
     def tearDown(self):
+        super().tearDown()
         self.mock_q_patched.stop()
 
     def test_options_converter(self):
@@ -193,10 +196,7 @@ class TestComponents(unittest.TestCase):
 
     @patch("directord.utils.file_sha3_224", autospec=True)
     @patch("os.path.isfile", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
-    def test__run_transfer_not_exists(
-        self, mock_log_debug, mock_isfile, mock_file_sha3_224
-    ):
+    def test__run_transfer_not_exists(self, mock_isfile, mock_file_sha3_224):
         mock_isfile.return_value = False
         mock_file_sha3_224.return_value = "YYYYYYYYY"
         with patch("builtins.open", unittest.mock.mock_open()):
@@ -211,13 +211,11 @@ class TestComponents(unittest.TestCase):
             )
         self.assertEqual(stdout, None)
         self.assertEqual(outcome, False)
-        mock_log_debug.assert_called()
 
     @patch("directord.utils.file_sha3_224", autospec=True)
     @patch("os.path.isfile", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     def test__run_transfer_not_exists_blueprinted(
-        self, mock_log_debug, mock_isfile, mock_file_sha3_224
+        self, mock_isfile, mock_file_sha3_224
     ):
         mock_isfile.return_value = False
         mock_file_sha3_224.return_value = "YYYYYYYYY"
@@ -234,17 +232,14 @@ class TestComponents(unittest.TestCase):
             )
         self.assertEqual(stdout, None)
         self.assertEqual(outcome, False)
-        mock_log_debug.assert_called()
 
     @patch("pwd.getpwnam", autospec=True)
     @patch("grp.getgrnam", autospec=True)
     @patch("directord.utils.file_sha3_224", autospec=True)
     @patch("os.path.isfile", autospec=True)
     @patch("os.chown", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     def test__run_transfer_not_chown_str(
         self,
-        mock_log_debug,
         mock_chown,
         mock_isfile,
         mock_file_sha3_224,
@@ -273,15 +268,12 @@ class TestComponents(unittest.TestCase):
             )
         self.assertEqual(stdout, None)
         self.assertEqual(outcome, False)
-        mock_log_debug.assert_called()
 
     @patch("directord.utils.file_sha3_224", autospec=True)
     @patch("os.path.isfile", autospec=True)
     @patch("os.chown", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     def test__run_transfer_not_chown_int(
         self,
-        mock_log_debug,
         mock_chown,
         mock_isfile,
         mock_file_sha3_224,
@@ -302,15 +294,12 @@ class TestComponents(unittest.TestCase):
             )
         self.assertEqual(stdout, None)
         self.assertEqual(outcome, False)
-        mock_log_debug.assert_called()
 
     @patch("directord.utils.file_sha3_224", autospec=True)
     @patch("os.path.isfile", autospec=True)
     @patch("os.chmod", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
     def test__run_transfer_not_mode(
         self,
-        mock_log_debug,
         mock_chmod,
         mock_isfile,
         mock_file_sha3_224,
@@ -330,7 +319,6 @@ class TestComponents(unittest.TestCase):
             )
         self.assertEqual(stdout, None)
         self.assertEqual(outcome, False)
-        mock_log_debug.assert_called()
 
     @patch("directord.components.ComponentBase.run_command", autospec=True)
     def test__dnf_command_success(self, mock_run_command):
@@ -546,8 +534,7 @@ class TestComponents(unittest.TestCase):
             start_new_session=False,
         )
 
-    @patch("logging.Logger.info", autospec=True)
-    def test_file_blueprinter(self, mock_log_info):
+    def test_file_blueprinter(self):
         fake_cache = tests.FakeCache()
         with patch(
             "builtins.open",
@@ -557,16 +544,13 @@ class TestComponents(unittest.TestCase):
                 cache=fake_cache, file_to="/test/file1"
             )
             self.assertTrue(success)
-        mock_log_info.assert_called()
 
-    @patch("logging.Logger.critical", autospec=True)
-    def test_file_blueprinter_failed(self, mock_log_critical):
+    def test_file_blueprinter_failed(self):
         fake_cache = tests.FakeCache()
         success, _ = self.components.file_blueprinter(
             cache=fake_cache, file_to="/test/file1"
         )
         self.assertFalse(success)
-        mock_log_critical.assert_called()
 
     @patch("directord.components.ComponentBase.run_command", autospec=True)
     def test__run_command(self, mock_run_command):
@@ -666,15 +650,13 @@ class TestComponents(unittest.TestCase):
             blueprinted_content, "No arguments were defined for blueprinting"
         )
 
-    @patch("logging.Logger.debug", autospec=True)
-    def test_blueprinter_failed(self, mock_log_debug):
+    def test_blueprinter_failed(self):
         _, blueprinted_content = self.components.blueprinter(
             content=tests.TEST_BLUEPRINT_CONTENT.encode(), values={"test": 1}
         )
         self.assertEqual(
             blueprinted_content, "Can't compile non template nodes"
         )
-        mock_log_debug.assert_called()
 
     @patch("time.sleep")
     def test_wait_seconds(self, mock_sleep):

--- a/directord/tests/test_datastore_disc.py
+++ b/directord/tests/test_datastore_disc.py
@@ -17,11 +17,12 @@ from unittest.mock import patch
 
 from directord.datastores import disc as datastore_disc
 
+from directord import tests
 
-class TestDatastoreDisc(unittest.TestCase):
+
+class TestDatastoreDisc(tests.TestBase):
     def setUp(self):
-        self.log_patched = patch("directord.logger.getLogger")
-        self.log = self.log_patched.start()
+        super().setUp()
         self.makedirs_patched = patch("os.makedirs", autospec=True)
         self.makedirs_patched.start()
         self.chdir_patched = patch("os.chdir", autospec=True)
@@ -31,7 +32,7 @@ class TestDatastoreDisc(unittest.TestCase):
         self.datastore = datastore_disc.BaseDocument(url="file:///test/things")
 
     def tearDown(self):
-        self.log_patched.stop()
+        super().tearDown()
         self.makedirs_patched.stop()
         self.chdir_patched.stop()
         self.setxattr_patched.stop()

--- a/directord/tests/test_datastore_internal.py
+++ b/directord/tests/test_datastore_internal.py
@@ -13,25 +13,20 @@
 #   under the License.
 
 import time
-import unittest
 
 from directord import datastores
+from directord import tests
 
 
-class TestDatastoreInternal(unittest.TestCase):
+class TestDatastoreInternal(tests.TestBase):
     def setUp(self):
-        self.log_patched = unittest.mock.patch("directord.logger.getLogger")
-        self.log = self.log_patched.start()
-
-    def tearDown(self):
-        self.log_patched.stop()
+        super().setUp()
 
     def test_wq_prune_0(self):
         workers = datastores.BaseDocument()
         workers["test"] = 1
         workers.empty()
         self.assertDictEqual(workers, dict())
-        self.log.debug.called_once()
 
     def test_wq_prune_valid(self):
         workers = datastores.BaseDocument()
@@ -41,7 +36,6 @@ class TestDatastoreInternal(unittest.TestCase):
         workers.prune()
         self.assertEqual(len(workers), 1)
         self.assertIn("valid1", workers)
-        self.log.debug.called_once()
 
     def test_wq_empty(self):
         workers = datastores.BaseDocument()

--- a/directord/tests/test_datastore_redis.py
+++ b/directord/tests/test_datastore_redis.py
@@ -19,11 +19,12 @@ import redis
 
 from directord.datastores import redis as datastore_redis
 
+from directord import tests
 
-class TestDatastoreRedis(unittest.TestCase):
+
+class TestDatastoreRedis(tests.TestBase):
     def setUp(self):
-        self.log_patched = patch("directord.logger.getLogger")
-        self.log = self.log_patched.start()
+        super().setUp()
         self.redis_patched = patch.object(
             redis.Redis, "from_url", autospec=True
         )
@@ -33,7 +34,7 @@ class TestDatastoreRedis(unittest.TestCase):
         )
 
     def tearDown(self):
-        self.log_patched.stop()
+        super().tearDown()
         self.redis_patched.stop()
 
     def test___getitem__string(self):

--- a/directord/tests/test_drivers_grpcd.py
+++ b/directord/tests/test_drivers_grpcd.py
@@ -27,8 +27,9 @@ except (ImportError, ModuleNotFoundError):
     GRPC_UNAVAILABLE = True
 
 
-class TestDriverGrpcdServerMode(unittest.TestCase):
+class TestDriverGrpcdServerMode(tests.TestBase):
     def setUp(self):
+        super().setUp()
         args = tests.FakeArgs()
         args.mode = "server"
         self.driver = grpcd.Driver(args=args)
@@ -36,9 +37,6 @@ class TestDriverGrpcdServerMode(unittest.TestCase):
         self.driver._client = self.client_mock
         self.server_mock = mock.MagicMock()
         self.driver._server = self.server_mock
-
-    def tearDown(self):
-        pass
 
     @mock.patch("directord.drivers.grpcd.MessageServiceClient.instance")
     @mock.patch("directord.drivers.grpcd.MessageServiceServer.instance")
@@ -389,17 +387,15 @@ class TestDriverGrpcdServerMode(unittest.TestCase):
         self.driver.key_generate("foo", "bar")
 
 
-class TestDriverGrpcdClientMode(unittest.TestCase):
+class TestDriverGrpcdClientMode(tests.TestBase):
     def setUp(self):
+        super().setUp()
         args = tests.FakeArgs()
         args.mode = "client"
         self.driver = grpcd.Driver(args=args)
         self.driver = grpcd.Driver(args=args)
         self.client_mock = mock.MagicMock()
         self.driver._client = self.client_mock
-
-    def tearDown(self):
-        pass
 
     @mock.patch("directord.drivers.grpcd.MessageServiceClient.instance")
     def test_grpc_init(self, mock_client_inst):
@@ -501,14 +497,16 @@ class TestDriverGrpcdClientMode(unittest.TestCase):
         )
 
 
-class TestGrpcQueueBase(unittest.TestCase):
+class TestGrpcQueueBase(tests.TestBase):
     """Test queue base."""
 
     def setUp(self):
+        super().setUp()
         grpcd.QueueBase._instance = None
         self.queue = grpcd.QueueBase.instance()
 
     def tearDown(self):
+        super().tearDown()
         grpcd.QueueBase._instance = None
 
     def test_instance(self):
@@ -554,7 +552,7 @@ class TestGrpcQueueBase(unittest.TestCase):
 
 
 @unittest.skipIf(GRPC_UNAVAILABLE, "grpc library unavailable")
-class TestGrpcServer(unittest.TestCase):
+class TestGrpcServer(tests.TestBase):
     """Test grpc server logic."""
 
     @mock.patch("directord.drivers.grpcd.MessageServiceServer._setup")
@@ -718,7 +716,7 @@ class TestGrpcServer(unittest.TestCase):
 
 
 @unittest.skipIf(GRPC_UNAVAILABLE, "grpc library unavailable")
-class TestGrpcClient(unittest.TestCase):
+class TestGrpcClient(tests.TestBase):
     """Test grpc client logic."""
 
     @mock.patch("directord.drivers.grpcd.MessageServiceClient.connect")

--- a/directord/tests/test_drivers_messaging.py
+++ b/directord/tests/test_drivers_messaging.py
@@ -13,7 +13,6 @@
 #   under the License.
 
 import json
-import unittest
 
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -23,8 +22,9 @@ from directord import tests
 from directord.drivers import messaging
 
 
-class TestDriverMessaging(unittest.TestCase):
+class TestDriverMessaging(tests.TestBase):
     def setUp(self):
+        super().setUp()
         self.mock_interface = MagicMock()
         args = tests.FakeArgs()
         args.driver = "messaging"
@@ -37,9 +37,6 @@ class TestDriverMessaging(unittest.TestCase):
                 args=args,
                 interface=self.mock_interface,
             )
-
-    def tearDown(self):
-        pass
 
     def test_get_lock(self):
         with patch("threading.Lock") as mock_lock:

--- a/directord/tests/test_logger.py
+++ b/directord/tests/test_logger.py
@@ -21,7 +21,7 @@ from directord import logger
 
 class TestLoggerHandlers(unittest.TestCase):
     def setUp(self):
-
+        super().setUp()
         self.rh_patched = unittest.mock.patch(
             "directord.logger.handlers.RotatingFileHandler"
         )
@@ -38,6 +38,7 @@ class TestLoggerHandlers(unittest.TestCase):
         self._handler = unittest.mock.Mock()
 
     def tearDown(self):
+        super().tearDown()
         self.rh_patched.stop()
         self.sh_patched.stop()
 

--- a/directord/tests/test_main.py
+++ b/directord/tests/test_main.py
@@ -23,8 +23,9 @@ from directord import main
 from directord import tests
 
 
-class TestMain(unittest.TestCase):
+class TestMain(tests.TestBase):
     def setUp(self):
+        super().setUp()
         self.maxDiff = 20000
         self.args = tests.FakeArgs()
         self.systemdinstall = main.SystemdInstall()
@@ -32,9 +33,6 @@ class TestMain(unittest.TestCase):
         mock_parse_driver_args = mock.Mock()
         mock_parse_driver_args.side_effect = parse_driver_args_se
         main._parse_driver_args = mock_parse_driver_args
-
-    def tearDown(self):
-        pass
 
     def test__args_default(self):
         self.assertRaises(

--- a/directord/tests/test_mixin.py
+++ b/directord/tests/test_mixin.py
@@ -64,9 +64,6 @@ class TestMixin(tests.TestConnectionBase):
         }
         self.target_orchestrations = [self.orchestration, self.orchestration]
 
-    def tearDown(self):
-        super().tearDown()
-
     def test_format_action_unknown(self):
         self.assertRaises(
             SystemExit,

--- a/directord/tests/test_user.py
+++ b/directord/tests/test_user.py
@@ -24,13 +24,11 @@ from directord import tests
 from directord import user
 
 
-class TestUser(unittest.TestCase):
+class TestUser(tests.TestBase):
     def setUp(self):
+        super().setUp()
         self.args = tests.FakeArgs()
         self.user = user.User(args=self.args)
-
-    def tearDown(self):
-        pass
 
     def test_send_data(self):
         user.directord.socket.socket = tests.MockSocket
@@ -42,9 +40,10 @@ class TestUser(unittest.TestCase):
 
 class TestManager(tests.TestDriverBase):
     def setUp(self):
-        super(TestManager, self).setUp()
+        super().setUp()
         self.args = tests.FakeArgs()
-        self.manage = user.Manage(args=self.args)
+        with patch("directord.plugin_import", autospec=True):
+            self.manage = user.Manage(args=self.args)
         self.manage.driver = self.mock_driver
 
     @patch("os.rename", autospec=True)
@@ -260,14 +259,3 @@ class TestManager(tests.TestDriverBase):
         mock_print.assert_called_with(
             '{\n    "args": {\n        "test": 1\n    },\n    "test": "value"\n}'  # noqa
         )
-
-    @patch("builtins.print")
-    @patch("os.chdir", autospec=True)
-    @patch("os.makedirs", autospec=True)
-    def test_run_override_dump_cache_empty(
-        self, mock_makedirs, mock_chdirs, mock_print
-    ):
-        self.manage.run(override="dump-cache")
-        mock_print.assert_called_with("{}")
-        mock_makedirs.assert_called()
-        mock_chdirs.assert_called()

--- a/directord/tests/test_utils.py
+++ b/directord/tests/test_utils.py
@@ -123,19 +123,14 @@ class TestUtils(tests.TestConnectionBase):
         )
 
     @patch("ssh.key.import_privkey_file", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
-    def test_sshconnect_keyfile(self, mock_log_debug, mock_import_key):
+    def test_sshconnect_keyfile(self, mock_import_key):
         with utils.SSHConnect(
             host="test", username="testuser", port=22, key_file="/test/key"
         ):
             mock_import_key.assert_called()
 
     @patch("ssh.key.import_privkey_file", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
-    @patch("logging.Logger.warning", autospec=True)
-    def test_sshconnect_agent_failure_default_key(
-        self, mock_log_debug, mock_log_warning, mock_import_key
-    ):
+    def test_sshconnect_agent_failure_default_key(self, mock_import_key):
         ssh = utils.SSHConnect(host="test", username="testuser", port=22)
         with patch.object(
             ssh.session, "userauth_agent", autospec=True


### PR DESCRIPTION
This change cleans up our unit tests so that we're not seeing all the
socket output from runs.

Like so...

```
Object allocated at (most recent call last):
  File "/home/cloudnull/projects/directord/directord/drivers/zmq.py", lineno 146
    self._context = zmq.Context()
```

This will help us better understand out test output and allow new folks
to better grok issues are they onboard.

A dummy driver was added to allow for easier testing across related
classes.

Signed-off-by: Kevin Carter <kevin@cloudnull.com>