### PR TITLE
Move the worker items into a object

### DIFF
--- a/.github/workflows/pull-request-functional.yml
+++ b/.github/workflows/pull-request-functional.yml
@@ -116,7 +116,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: functional-test-logs
+          name: functional-messaging-test-logs
           path: /tmp/directord*
 
   functional_grpcd_check:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ And voila here is our first orchestrated hello world:
 KEY                   VALUE
 --------------------  -------------------------------------------------------
 ID                    9bcf31cb-7faf-4367-bf37-57c11b3f81dc
-ACCEPTED              True
 INFO                  test1 = hello world
                       test2 = hello world
 STDOUT                test1 = hello world

--- a/directord/datastores/__init__.py
+++ b/directord/datastores/__init__.py
@@ -21,12 +21,16 @@ class BaseDocument(dict):
     def prune(self):
         """Prune items that have a time based expiry."""
 
-        for (key, value) in list(self.items()):
+        for key, value in list(self.items()):
             try:
-                if time.time() >= value["time"]:
+                if value.expired:
                     self.pop(key)
-            except (KeyError, TypeError):
-                pass
+            except (AttributeError, KeyError):
+                try:
+                    if time.time() >= value["time"]:
+                        self.pop(key)
+                except (KeyError, TypeError):
+                    pass
 
         return len(self)
 

--- a/directord/datastores/redis.py
+++ b/directord/datastores/redis.py
@@ -104,6 +104,12 @@ class BaseDocument:
 
         return [i.decode() for i in self.datastore.keys("*")]
 
+    def values(self):
+        """Yield a each value."""
+
+        for item in self.datastore.keys("*"):
+            yield self.__getitem__(item)
+
     def clear(self):
         """Empty all items from the datastore.
 

--- a/directord/datastores/redis.py
+++ b/directord/datastores/redis.py
@@ -68,16 +68,13 @@ class BaseDocument:
         except AttributeError:
             pass
 
-        if isinstance(value, dict):
-            try:
-                expire = int(value.get("time") - time.time())
-            except TypeError:
-                expire = None
-            else:
-                if expire < 1:
-                    expire = 1
-        else:
+        try:
+            expire = int(value.get("time") - time.time())
+        except (AttributeError, TypeError):
             expire = None
+        else:
+            if expire < 1:
+                expire = 1
 
         self.datastore.set(key, pickle.dumps(value), ex=expire)
 
@@ -102,7 +99,8 @@ class BaseDocument:
         :returns: List
         """
 
-        return [i.decode() for i in self.datastore.keys("*")]
+        for item in self.datastore.keys("*"):
+            yield item.decode()
 
     def values(self):
         """Yield a each value."""
@@ -132,7 +130,10 @@ class BaseDocument:
     def prune(self):
         """Prune items that have a time based expiry."""
 
-        return len(self.keys())
+        count = 0
+        for _ in self.keys():
+            count += 1
+        return count
 
     def get(self, key):
         """Return the value of a given key.

--- a/directord/drivers/messaging.py
+++ b/directord/drivers/messaging.py
@@ -432,10 +432,11 @@ class Driver(drivers.BaseDriver):
             worker = self.interface.workers.get(identity)
             target = worker.machine_id
 
-            if not target:
+            if not worker.machine_id:
                 self.log.fatal(
                     "Machine ID for identity [ %s ] not found", identity
                 )
+                return
 
         self._send(
             method=method,

--- a/directord/drivers/messaging.py
+++ b/directord/drivers/messaging.py
@@ -430,7 +430,7 @@ class Driver(drivers.BaseDriver):
             identity = self.identity
         else:
             worker = self.interface.workers.get(identity)
-            target = worker.get("machine_id")
+            target = worker.machine_id
 
             if not target:
                 self.log.fatal(

--- a/directord/interface.py
+++ b/directord/interface.py
@@ -12,6 +12,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
+import decimal
 import logging
 import os
 import time
@@ -93,18 +94,17 @@ class Interface(directord.Processor):
 class Worker:
     """Worker class object."""
 
-    expire_time = None
-    machine_id = None
-    version = None
-    host_uptime = None
-    agent_uptime = None
-    version = None
-    driver = None
-
     def __init__(self, identity):
         """Initialize the worker object."""
 
         self.identity = identity
+        self.expire_time = None
+        self.machine_id = None
+        self.version = None
+        self.host_uptime = None
+        self.agent_uptime = None
+        self.version = None
+        self.driver = None
 
     @property
     def expired(self):
@@ -125,17 +125,116 @@ class Worker:
 class Job:
     """Job class object."""
 
-    INFO = dict()
-    STDOUT = dict()
-    STDERR = dict()
-    _createtime = time.time()
-    _executiontime = dict()
-    _roundtripltime = dict()
-    _processing = dict()
-
-    def __init__(self):
+    def __init__(self, job_item):
         """Initialize the job object."""
+
+        self._createtime = time.time()
+        self._executiontime = dict()
+        self._lasttime = time.time()
+        self._processing = dict()
+        self._roundtripltime = dict()
+
+        self.job_id = job_item["job_id"]
+
+        self.JOB_DEFINITION = job_item
+        self.JOB_SHA3_224 = job_item["job_sha3_224"]
+        self.JOB_NAME = job_item.get("job_name", self.JOB_SHA3_224)
+        self.PARENT_JOB_ID = job_item.get("parent_id")
+        self.PARENT_JOB_NAME = job_item.get("parent_name", self.PARENT_JOB_ID)
+        self.VERB = job_item["verb"]
+        self.COMPONENT_TIMESTAMP = None
+        self.INFO = dict()
+        self.PROCESSING = None
+        self.RETURN_TIMESTAMP = None
+        self.STDERR = dict()
+        self.STDOUT = dict()
+
+    @property
+    def failed(self):
+        """Return True or Flase if job failed."""
+
+        return len(self.failed_nodes) > 0
 
     @property
     def _nodes(self):
-        pass
+        """Return a sorted list of all nodes."""
+
+        return sorted(self._processing.keys())
+
+    def _check_nodes(self, status_code):
+        """Return a list of nodes based on a defined status code.
+
+        :param status_code: Status code string.
+        :type status_code: String
+        :returns: List
+        """
+        nodes = list()
+        for k, v in self._processing.items():
+            if v == status_code:
+                nodes.append(k)
+        return nodes
+
+    @property
+    def failed_nodes(self):
+        """Return a list of failed nodes."""
+
+        return self._check_nodes(status_code="\x15")
+
+    @property
+    def success_nodes(self):
+        """Return a list of success nodes."""
+
+        return self._check_nodes(status_code="\x04")
+
+    @property
+    def processing(self):
+        """Set the processing flag and return boolean if processing."""
+
+        processing = any(self._check_nodes(status_code="\x16"))
+        if processing:
+            self.PROCESSING = "\x16"
+        else:
+            self.PROCESSING = "\x04"
+        return processing
+
+    def set_roundtripltime(self, identity, recv_time):
+        """Set the round trip time.
+
+        The constante ROUNDTRIP_TIME is used to represent the average
+        roundtrip time.
+        """
+
+        if isinstance(recv_time, (int, float)):
+            self._roundtripltime[identity] = (
+                float(recv_time) - self._createtime
+            )
+
+        try:
+            self.ROUNDTRIP_TIME = "{:.8f}".format(
+                decimal.Decimal(
+                    sum(self._roundtripltime.values())
+                    / len(self._roundtripltime.keys())
+                )
+            )
+        except ZeroDivisionError:
+            pass
+
+    def set_executiontime(self, identity, execution_time):
+        """Set the execution time.
+
+        The constante EXECUTION_TIME is used to represent the average
+        execution time.
+        """
+
+        if isinstance(execution_time, (int, float)):
+            self._executiontime[identity] = float(execution_time)
+
+        try:
+            self.EXECUTION_TIME = "{:.8f}".format(
+                decimal.Decimal(
+                    sum(self._executiontime.values())
+                    / len(self._executiontime.keys())
+                )
+            )
+        except ZeroDivisionError:
+            pass

--- a/directord/interface.py
+++ b/directord/interface.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import time
 
 import directord
 
@@ -87,3 +88,54 @@ class Interface(directord.Processor):
                         self.args.driver, str(e)
                     )
                 ) from None
+
+
+class Worker:
+    """Worker class object."""
+
+    expire_time = None
+    machine_id = None
+    version = None
+    host_uptime = None
+    agent_uptime = None
+    version = None
+    driver = None
+
+    def __init__(self, identity):
+        """Initialize the worker object."""
+
+        self.identity = identity
+
+    @property
+    def expired(self):
+        """Return Boolean, True if expiry is greater than Now or None."""
+
+        if self.expiry is None:
+            return True
+        else:
+            return time.time() >= self.expire_time
+
+    @property
+    def expiry(self):
+        """Return Float, for expiry."""
+
+        return self.expire_time - time.time()
+
+
+class Job:
+    """Job class object."""
+
+    INFO = dict()
+    STDOUT = dict()
+    STDERR = dict()
+    _createtime = time.time()
+    _executiontime = dict()
+    _roundtripltime = dict()
+    _processing = dict()
+
+    def __init__(self):
+        """Initialize the job object."""
+
+    @property
+    def _nodes(self):
+        pass

--- a/directord/server.py
+++ b/directord/server.py
@@ -13,7 +13,6 @@
 #   under the License.
 
 import base64
-import decimal
 import grp
 import json
 import os
@@ -127,83 +126,44 @@ class Server(interface.Interface):
         :type recv_tim: Float
         """
 
-        def _set_time():
-            _createtime = job_metadata.get("_createtime")
-            if not _createtime:
-                _createtime = job_metadata["_createtime"] = time.time()
-
-            if isinstance(recv_time, (int, float)):
-                job_metadata["_roundtripltime"][identity] = (
-                    float(recv_time) - _createtime
-                )
-                job_metadata["ROUNDTRIP_TIME"] = "{:.8f}".format(
-                    decimal.Decimal(
-                        sum(job_metadata["_roundtripltime"].values())
-                        / len(job_metadata["_roundtripltime"].keys())
-                    )
-                )
-
-            if isinstance(execution_time, (int, float)):
-                job_metadata["_executiontime"][identity] = float(
-                    execution_time
-                )
-                job_metadata["EXECUTION_TIME"] = "{:.8f}".format(
-                    decimal.Decimal(
-                        sum(job_metadata["_executiontime"].values())
-                        / len(job_metadata["_executiontime"].keys())
-                    )
-                )
-
-        job_metadata = self.return_jobs.get(job_id)
-        if not job_metadata:
+        try:
+            job_metadata = self.return_jobs[job_id]
+        except KeyError:
             return
 
         if job_output and job_output is not self.driver.nullbyte:
-            job_metadata["INFO"][identity] = job_output
+            job_metadata.INFO[identity] = job_output
 
         if job_stdout and job_stdout is not self.driver.nullbyte:
-            job_metadata["STDOUT"][identity] = job_stdout
+            job_metadata.STDOUT[identity] = job_stdout
 
         if job_stderr and job_stderr is not self.driver.nullbyte:
-            job_metadata["STDERR"][identity] = job_stderr
+            job_metadata.STDERR[identity] = job_stderr
 
-        job_metadata["_processing"][identity] = job_status
-        if job_status == self.driver.job_processing:
-            self.log.debug(
-                "Job [ %s ] processing for [ %s ]", job_id, identity
-            )
+        job_metadata._processing[identity] = job_status
+
+        job_metadata.set_roundtripltime(identity=identity, recv_time=recv_time)
+
+        job_metadata.set_executiontime(
+            identity=identity, execution_time=execution_time
+        )
+
+        job_metadata.RETURN_TIMESTAMP = return_timestamp
+
+        job_metadata.COMPONENT_TIMESTAMP = component_exec_timestamp
+
+        if job_metadata.processing:
+            self.log.debug("Job [ %s ] processing", job_id)
         elif job_status == self.driver.job_end:
-            _set_time()
             self.log.debug(
-                "Job [ %s ] finished processing for [ %s ]", job_id, identity
+                "Job [ %s ] success for [ %s ]",
+                job_id,
+                identity,
             )
-            if "SUCCESS" in job_metadata:
-                job_metadata["SUCCESS"].append(identity)
-            else:
-                job_metadata["SUCCESS"] = [identity]
-            job_metadata["_processing"][identity] = self.driver.job_end
         elif job_status == self.driver.job_failed:
-            _set_time()
             self.log.warning("Job [ %s ] failed for [ %s ]", job_id, identity)
-            if "FAILED" in job_metadata:
-                job_metadata["FAILED"].append(identity)
-            else:
-                job_metadata["FAILED"] = [identity]
 
-        if return_timestamp:
-            job_metadata["RETURN_TIMESTAMP"] = return_timestamp
-
-        if component_exec_timestamp:
-            job_metadata["COMPONENT_TIMESTAMP"] = component_exec_timestamp
-
-        for process in job_metadata["_processing"].values():
-            if process == self.driver.job_processing:
-                job_metadata["PROCESSING"] = self.driver.job_processing
-                break
-        else:
-            job_metadata["PROCESSING"] = self.driver.job_end
-
-        job_metadata["_lasttime"] = time.time()
+        job_metadata._lasttime = time.time()
 
         self.return_jobs[job_id] = job_metadata
 
@@ -218,36 +178,20 @@ class Server(interface.Interface):
         :type targets: List
         """
 
-        _nodes = set()
+        _job = interface.Job(job_item=job_item)
         for target in targets:
             try:
                 target = target.decode()
             except AttributeError:
                 pass
-            _nodes.add(target)
+            _job._processing[target] = self.driver.nullbyte
+            _job._roundtripltime[target] = 0
+            _job._executiontime[target] = 0
+            _job.INFO[target] = None
+            _job.STDERR[target] = None
+            _job.STDOUT[target] = None
 
-        return self.return_jobs.set(
-            task,
-            {
-                "ACCEPTED": True,
-                "INFO": dict(),
-                "STDOUT": dict(),
-                "STDERR": dict(),
-                "_nodes": sorted(_nodes),
-                "VERB": job_item["verb"],
-                "JOB_SHA3_224": job_item["job_sha3_224"],
-                "JOB_NAME": job_item.get("job_name", job_item["job_sha3_224"]),
-                "JOB_DEFINITION": job_item,
-                "PARENT_JOB_ID": job_item.get("parent_id"),
-                "PARENT_JOB_NAME": job_item.get(
-                    "parent_name", job_item.get("parent_id")
-                ),
-                "_createtime": time.time(),
-                "_executiontime": dict(),
-                "_roundtripltime": dict(),
-                "_processing": dict(),
-            },
-        )
+        return self.return_jobs.set(task, _job)
 
     def exit_gracefully(self, *args, **kwargs):
         """Set the driver event to begin the shutdown of the application."""
@@ -668,26 +612,30 @@ class Server(interface.Interface):
         :type job_id: String
         """
 
-        _nodes = len(self.return_jobs[job_id]["_nodes"])
+        start_time = time.time()
         while True:
-            if self.return_jobs[job_id].get("FAILED"):
+            if self.return_jobs[job_id].failed:
                 self.log.critical(
                     "Query job [ %s ] encountered failures.", job_id
                 )
                 return
-            elif len(self.return_jobs[job_id]["STDOUT"].keys()) >= _nodes:
+            elif all(self.return_jobs[job_id].STDOUT.values()):
                 break
+            elif start_time + 600 >= time.time():
+                self.log.error(
+                    "Query job [ %s ] encountered a timeout.", job_id
+                )
+                return
 
             self.log.info("Waiting for [ %s ], QUERY to complete", job_id)
             time.sleep(1)
 
-        job_return = self.return_jobs[job_id]
         new_task = dict()
         new_task["skip_cache"] = True
         new_task["extend_args"] = True
         new_task["verb"] = "ARG"
         query_data = dict()
-        for k, v in job_return["STDOUT"].items():
+        for k, v in self.return_jobs[job_id].STDOUT.items():
             query_data[k] = json.loads(v)
         new_task["args"] = {"query": query_data}
         new_task["parent_async_bypass"] = True
@@ -731,6 +679,15 @@ class Server(interface.Interface):
         ID can be defined in the data. If a task ID is not defined one will
         be generated.
         """
+
+        def _node_return_info(node_info):
+            """Return a dictionary of parsed node information."""
+
+            _node_info = node_info.__dict__
+            _node_info["_nodes"] = node_info._nodes
+            _node_info["SUCCESS"] = node_info.success_nodes
+            _node_info["FAILED"] = node_info.failed_nodes
+            return _node_info
 
         try:
             os.unlink(self.args.socket_path)
@@ -779,12 +736,21 @@ class Server(interface.Interface):
                             item["expiry"] = v.expiry
                             data.append((v.identity, item))
                     elif key == "list_jobs":
-                        data = [
-                            (str(k), v) for k, v in self.return_jobs.items()
-                        ]
+                        data = list()
+                        for k, v in self.return_jobs.items():
+                            data.append(
+                                (str(k), _node_return_info(node_info=v))
+                            )
                     elif key == "job_info":
                         try:
-                            data = [(str(value), self.return_jobs[value])]
+                            data = [
+                                (
+                                    str(value),
+                                    _node_return_info(
+                                        node_info=self.return_jobs[value]
+                                    ),
+                                )
+                            ]
                         except KeyError:
                             data = []
                     elif key == "purge_nodes":
@@ -847,12 +813,9 @@ class Server(interface.Interface):
         :type data: Dict
         """
 
-        if identity in self.workers:
-            worker = self.workers[identity]
-        else:
-            worker = self.workers[identity] = interface.Worker(
-                identity=identity
-            )
+        worker = self.workers.get(identity)
+        if worker is None:
+            worker = interface.Worker(identity=identity)
 
         worker.expire_time = self.driver.get_expiry(
             heartbeat_interval=self.heartbeat_interval,

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -35,67 +35,50 @@ class TestServer(tests.TestDriverBase):
         self.server.workers = datastores.BaseDocument()
         self.server.return_jobs = datastores.BaseDocument()
         self.server.driver = self.mock_driver
+        self.job_item = {
+            "job_id": "XXX",
+            "job_sha3_224": "YYY",
+            "parent_id": "ZZZ",
+            "verb": "TEST",
+        }
+        self.server.create_return_jobs(
+            task="XXX", job_item=self.job_item, targets=["test-node"]
+        )
 
     def test__set_job_status(self):
-        self.server.return_jobs = {
-            "XXX": {
-                "ACCEPTED": True,
-                "INFO": dict(),
-                "STDOUT": dict(),
-                "STDERR": dict(),
-                "_nodes": ["test-node"],
-                "VERB": "RUN",
-                "JOB_SHA3_224": "YYY",
-                "JOB_DEFINITION": {},
-                "PARENT_JOB_ID": "ZZZ",
-                "_createtime": 1,
-                "_lasttime": ANY,
-                "_processing": {"test-node": "\x16"},
-            }
-        }
         self.server._set_job_status(
             job_status=self.server.driver.job_processing,
             job_id="XXX",
             identity="test-node",
             job_output="output",
         )
-
         self.assertDictEqual(
-            self.server.return_jobs["XXX"],
+            self.server.return_jobs["XXX"].__dict__,
             {
-                "ACCEPTED": True,
-                "INFO": {"test-node": "output"},
-                "JOB_DEFINITION": {},
-                "_nodes": ["test-node"],
-                "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x16",
-                "STDERR": {},
-                "STDOUT": {},
-                "JOB_SHA3_224": "YYY",
-                "VERB": "RUN",
-                "_createtime": 1,
+                "_createtime": ANY,
+                "_executiontime": {"test-node": 0},
                 "_lasttime": ANY,
                 "_processing": {"test-node": "\x16"},
+                "_roundtripltime": {"test-node": 0},
+                "job_id": "XXX",
+                "JOB_DEFINITION": ANY,
+                "JOB_SHA3_224": "YYY",
+                "JOB_NAME": "YYY",
+                "PARENT_JOB_ID": "ZZZ",
+                "PARENT_JOB_NAME": "ZZZ",
+                "VERB": "TEST",
+                "COMPONENT_TIMESTAMP": None,
+                "INFO": {"test-node": "output"},
+                "PROCESSING": "\x16",
+                "RETURN_TIMESTAMP": None,
+                "STDERR": {"test-node": None},
+                "STDOUT": {"test-node": None},
+                "ROUNDTRIP_TIME": "0.00000000",
+                "EXECUTION_TIME": "0.00000000",
             },
         )
 
     def test__set_job_status_stdout(self):
-        self.server.return_jobs = {
-            "XXX": {
-                "ACCEPTED": True,
-                "INFO": dict(),
-                "STDOUT": dict(),
-                "STDERR": dict(),
-                "_nodes": ["test-node"],
-                "VERB": "RUN",
-                "JOB_SHA3_224": "YYY",
-                "JOB_DEFINITION": {},
-                "PARENT_JOB_ID": "ZZZ",
-                "_createtime": 1,
-                "_lasttime": ANY,
-                "_processing": dict(),
-            }
-        }
         self.server._set_job_status(
             job_status=self.server.driver.job_processing,
             job_id="XXX",
@@ -103,43 +86,33 @@ class TestServer(tests.TestDriverBase):
             job_output="output",
             job_stdout="stdout",
         )
-
         self.assertDictEqual(
-            self.server.return_jobs["XXX"],
+            self.server.return_jobs["XXX"].__dict__,
             {
-                "ACCEPTED": True,
-                "INFO": {"test-node": "output"},
-                "JOB_DEFINITION": {},
-                "_nodes": ["test-node"],
-                "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x16",
-                "STDERR": {},
-                "STDOUT": {"test-node": "stdout"},
-                "JOB_SHA3_224": "YYY",
-                "VERB": "RUN",
-                "_createtime": 1,
+                "_createtime": ANY,
+                "_executiontime": {"test-node": 0},
                 "_lasttime": ANY,
                 "_processing": {"test-node": "\x16"},
+                "_roundtripltime": {"test-node": 0},
+                "job_id": "XXX",
+                "JOB_DEFINITION": ANY,
+                "JOB_SHA3_224": "YYY",
+                "JOB_NAME": "YYY",
+                "PARENT_JOB_ID": "ZZZ",
+                "PARENT_JOB_NAME": "ZZZ",
+                "VERB": "TEST",
+                "COMPONENT_TIMESTAMP": None,
+                "INFO": {"test-node": "output"},
+                "PROCESSING": "\x16",
+                "RETURN_TIMESTAMP": None,
+                "STDERR": {"test-node": None},
+                "STDOUT": {"test-node": "stdout"},
+                "ROUNDTRIP_TIME": "0.00000000",
+                "EXECUTION_TIME": "0.00000000",
             },
         )
 
     def test__set_job_status_stderr(self):
-        self.server.return_jobs = {
-            "XXX": {
-                "ACCEPTED": True,
-                "INFO": dict(),
-                "STDOUT": dict(),
-                "STDERR": dict(),
-                "_nodes": ["test-node"],
-                "VERB": "RUN",
-                "JOB_SHA3_224": "YYY",
-                "JOB_DEFINITION": {},
-                "PARENT_JOB_ID": "ZZZ",
-                "_createtime": 1,
-                "_lasttime": ANY,
-                "_processing": {"test-node": "\x04"},
-            }
-        }
         self.server._set_job_status(
             job_status=self.server.driver.job_processing,
             job_id="XXX",
@@ -147,197 +120,161 @@ class TestServer(tests.TestDriverBase):
             job_output="output",
             job_stderr="stderr",
         )
-
         self.assertDictEqual(
-            self.server.return_jobs["XXX"],
+            self.server.return_jobs["XXX"].__dict__,
             {
-                "ACCEPTED": True,
-                "INFO": {"test-node": "output"},
-                "JOB_DEFINITION": {},
-                "_nodes": ["test-node"],
-                "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x16",
-                "STDERR": {"test-node": "stderr"},
-                "STDOUT": {},
-                "JOB_SHA3_224": "YYY",
-                "VERB": "RUN",
-                "_createtime": 1,
+                "_createtime": ANY,
+                "_executiontime": {"test-node": 0},
                 "_lasttime": ANY,
                 "_processing": {"test-node": "\x16"},
+                "_roundtripltime": {"test-node": 0},
+                "job_id": "XXX",
+                "JOB_DEFINITION": ANY,
+                "JOB_SHA3_224": "YYY",
+                "JOB_NAME": "YYY",
+                "PARENT_JOB_ID": "ZZZ",
+                "PARENT_JOB_NAME": "ZZZ",
+                "VERB": "TEST",
+                "COMPONENT_TIMESTAMP": None,
+                "INFO": {"test-node": "output"},
+                "PROCESSING": "\x16",
+                "RETURN_TIMESTAMP": None,
+                "STDERR": {"test-node": "stderr"},
+                "STDOUT": {"test-node": None},
+                "ROUNDTRIP_TIME": "0.00000000",
+                "EXECUTION_TIME": "0.00000000",
             },
         )
 
     def test__set_job_processing(self):
-        self.server.return_jobs = {
-            "XXX": {
-                "ACCEPTED": True,
-                "INFO": dict(),
-                "STDOUT": dict(),
-                "STDERR": dict(),
-                "_nodes": ["test-node"],
-                "VERB": "RUN",
-                "JOB_SHA3_224": "YYY",
-                "JOB_DEFINITION": {},
-                "PARENT_JOB_ID": "ZZZ",
-                "_createtime": 1,
-                "_lasttime": ANY,
-                "_processing": {"test-node": "\x16"},
-            }
-        }
         self.server._set_job_status(
             job_status=self.server.driver.job_processing,
             job_id="XXX",
             identity="test-node",
             job_output="output",
         )
-
         self.assertDictEqual(
-            self.server.return_jobs["XXX"],
+            self.server.return_jobs["XXX"].__dict__,
             {
-                "ACCEPTED": True,
-                "INFO": {"test-node": "output"},
-                "JOB_DEFINITION": {},
-                "_nodes": ["test-node"],
-                "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x16",
-                "STDERR": {},
-                "STDOUT": {},
-                "JOB_SHA3_224": "YYY",
-                "VERB": "RUN",
-                "_createtime": 1,
+                "_createtime": ANY,
+                "_executiontime": {"test-node": 0},
                 "_lasttime": ANY,
                 "_processing": {"test-node": "\x16"},
+                "_roundtripltime": {"test-node": 0},
+                "job_id": "XXX",
+                "JOB_DEFINITION": ANY,
+                "JOB_SHA3_224": "YYY",
+                "JOB_NAME": "YYY",
+                "PARENT_JOB_ID": "ZZZ",
+                "PARENT_JOB_NAME": "ZZZ",
+                "VERB": "TEST",
+                "COMPONENT_TIMESTAMP": None,
+                "INFO": {"test-node": "output"},
+                "PROCESSING": "\x16",
+                "RETURN_TIMESTAMP": None,
+                "STDERR": {"test-node": None},
+                "STDOUT": {"test-node": None},
+                "ROUNDTRIP_TIME": "0.00000000",
+                "EXECUTION_TIME": "0.00000000",
             },
         )
 
     def test__set_job_end(self):
-        self.server.return_jobs = {
-            "XXX": {
-                "ACCEPTED": True,
-                "INFO": dict(),
-                "STDOUT": dict(),
-                "STDERR": dict(),
-                "_nodes": ["test-node"],
-                "VERB": "RUN",
-                "JOB_SHA3_224": "YYY",
-                "JOB_DEFINITION": {},
-                "PARENT_JOB_ID": "ZZZ",
-                "_createtime": 1,
-                "_lasttime": ANY,
-                "_processing": {"test-node": "\x04"},
-            }
-        }
         self.server._set_job_status(
             job_status=self.server.driver.job_end,
             job_id="XXX",
             identity="test-node",
             job_output="output",
         )
-
         self.assertDictEqual(
-            self.server.return_jobs["XXX"],
+            self.server.return_jobs["XXX"].__dict__,
             {
-                "ACCEPTED": True,
-                "INFO": {"test-node": "output"},
-                "JOB_DEFINITION": {},
-                "_nodes": ["test-node"],
-                "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x04",
-                "STDERR": {},
-                "STDOUT": {},
-                "SUCCESS": ["test-node"],
-                "JOB_SHA3_224": "YYY",
-                "VERB": "RUN",
-                "_createtime": 1,
+                "_createtime": ANY,
+                "_executiontime": {"test-node": 0},
                 "_lasttime": ANY,
                 "_processing": {"test-node": "\x04"},
+                "_roundtripltime": {"test-node": 0},
+                "job_id": "XXX",
+                "JOB_DEFINITION": ANY,
+                "JOB_SHA3_224": "YYY",
+                "JOB_NAME": "YYY",
+                "PARENT_JOB_ID": "ZZZ",
+                "PARENT_JOB_NAME": "ZZZ",
+                "VERB": "TEST",
+                "COMPONENT_TIMESTAMP": None,
+                "INFO": {"test-node": "output"},
+                "PROCESSING": "\x04",
+                "RETURN_TIMESTAMP": None,
+                "STDERR": {"test-node": None},
+                "STDOUT": {"test-node": None},
+                "ROUNDTRIP_TIME": "0.00000000",
+                "EXECUTION_TIME": "0.00000000",
             },
         )
 
     def test__set_job_null(self):
-        self.server.return_jobs = {
-            "XXX": {
-                "ACCEPTED": True,
-                "INFO": dict(),
-                "STDOUT": dict(),
-                "STDERR": dict(),
-                "_nodes": ["test-node"],
-                "VERB": "RUN",
-                "JOB_SHA3_224": "YYY",
-                "JOB_DEFINITION": {},
-                "PARENT_JOB_ID": "ZZZ",
-                "_createtime": 1,
-                "_lasttime": ANY,
-                "_processing": {"test-node": "\x00"},
-            }
-        }
         self.server._set_job_status(
             job_status=self.server.driver.nullbyte,
             job_id="XXX",
             identity="test-node",
             job_output="output",
         )
-
         self.assertDictEqual(
-            self.server.return_jobs["XXX"],
+            self.server.return_jobs["XXX"].__dict__,
             {
-                "ACCEPTED": True,
-                "INFO": {"test-node": "output"},
-                "JOB_DEFINITION": {},
-                "_nodes": ["test-node"],
-                "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x04",
-                "STDERR": {},
-                "STDOUT": {},
-                "JOB_SHA3_224": "YYY",
-                "VERB": "RUN",
-                "_createtime": 1,
+                "_createtime": ANY,
+                "_executiontime": {"test-node": 0},
                 "_lasttime": ANY,
                 "_processing": {"test-node": "\x00"},
+                "_roundtripltime": {"test-node": 0},
+                "job_id": "XXX",
+                "JOB_DEFINITION": ANY,
+                "JOB_SHA3_224": "YYY",
+                "JOB_NAME": "YYY",
+                "PARENT_JOB_ID": "ZZZ",
+                "PARENT_JOB_NAME": "ZZZ",
+                "VERB": "TEST",
+                "COMPONENT_TIMESTAMP": None,
+                "INFO": {"test-node": "output"},
+                "PROCESSING": "\x04",
+                "RETURN_TIMESTAMP": None,
+                "STDERR": {"test-node": None},
+                "STDOUT": {"test-node": None},
+                "ROUNDTRIP_TIME": "0.00000000",
+                "EXECUTION_TIME": "0.00000000",
             },
         )
 
     def test__set_job_failed(self):
-        self.server.return_jobs = {
-            "XXX": {
-                "ACCEPTED": True,
-                "INFO": dict(),
-                "STDOUT": dict(),
-                "STDERR": dict(),
-                "_nodes": ["test-node"],
-                "VERB": "RUN",
-                "JOB_SHA3_224": "YYY",
-                "JOB_DEFINITION": {},
-                "PARENT_JOB_ID": "ZZZ",
-                "_createtime": 1,
-                "_lasttime": ANY,
-                "_processing": {"test-node": "\x15"},
-            }
-        }
         self.server._set_job_status(
             job_status=self.server.driver.job_failed,
             job_id="XXX",
             identity="test-node",
             job_output="output",
         )
-
         self.assertDictEqual(
-            self.server.return_jobs["XXX"],
+            self.server.return_jobs["XXX"].__dict__,
             {
-                "ACCEPTED": True,
-                "INFO": {"test-node": "output"},
-                "JOB_DEFINITION": {},
-                "_nodes": ["test-node"],
-                "PARENT_JOB_ID": "ZZZ",
-                "PROCESSING": "\x04",
-                "STDERR": {},
-                "STDOUT": {},
-                "FAILED": ["test-node"],
-                "JOB_SHA3_224": "YYY",
-                "VERB": "RUN",
-                "_createtime": 1,
+                "_createtime": ANY,
+                "_executiontime": {"test-node": 0},
                 "_lasttime": ANY,
                 "_processing": {"test-node": "\x15"},
+                "_roundtripltime": {"test-node": 0},
+                "job_id": "XXX",
+                "JOB_DEFINITION": ANY,
+                "JOB_SHA3_224": "YYY",
+                "JOB_NAME": "YYY",
+                "PARENT_JOB_ID": "ZZZ",
+                "PARENT_JOB_NAME": "ZZZ",
+                "VERB": "TEST",
+                "COMPONENT_TIMESTAMP": None,
+                "INFO": {"test-node": "output"},
+                "PROCESSING": "\x04",
+                "RETURN_TIMESTAMP": None,
+                "STDERR": {"test-node": None},
+                "STDOUT": {"test-node": None},
+                "ROUNDTRIP_TIME": "0.00000000",
+                "EXECUTION_TIME": "0.00000000",
             },
         )
 
@@ -374,79 +311,67 @@ class TestServer(tests.TestDriverBase):
         self.mock_driver.backend_send.assert_called()
 
     def test_create_return_jobs(self):
-        self.server.return_jobs = datastores.BaseDocument()
         status = self.server.create_return_jobs(
             task="XXX",
-            job_item={
-                "verb": "TEST",
-                "job_sha3_224": "YYY",
-                "parent_id": "ZZZ",
-            },
+            job_item=self.job_item,
             targets=["test-node1", "test-node2"],
         )
         self.assertDictEqual(
-            status,
+            status.__dict__,
             {
-                "ACCEPTED": True,
-                "INFO": {},
-                "JOB_DEFINITION": {
-                    "parent_id": "ZZZ",
-                    "job_sha3_224": "YYY",
-                    "verb": "TEST",
-                },
-                "_nodes": ["test-node1", "test-node2"],
+                "_createtime": ANY,
+                "_executiontime": {"test-node": 0},
+                "_lasttime": ANY,
+                "_processing": {"test-node": "\x00"},
+                "_roundtripltime": {"test-node": 0},
+                "job_id": "XXX",
+                "JOB_DEFINITION": ANY,
+                "JOB_SHA3_224": "YYY",
+                "JOB_NAME": "YYY",
                 "PARENT_JOB_ID": "ZZZ",
                 "PARENT_JOB_NAME": "ZZZ",
-                "STDERR": {},
-                "STDOUT": {},
-                "JOB_NAME": "YYY",
-                "JOB_SHA3_224": "YYY",
                 "VERB": "TEST",
-                "_createtime": ANY,
-                "_processing": ANY,
-                "_executiontime": ANY,
-                "_roundtripltime": ANY,
+                "COMPONENT_TIMESTAMP": None,
+                "INFO": {"test-node": None},
+                "PROCESSING": None,
+                "RETURN_TIMESTAMP": None,
+                "STDERR": {"test-node": None},
+                "STDOUT": {"test-node": None},
             },
         )
 
     def test_create_return_jobs_named(self):
         self.maxDiff = 1024
         self.server.return_jobs = datastores.BaseDocument()
+        job_item = self.job_item.copy()
+        job_item["parent_name"] = "test parent name"
+        job_item["job_name"] = "test job name"
         status = self.server.create_return_jobs(
             task="XXX",
-            job_item={
-                "verb": "TEST",
-                "job_sha3_224": "YYY",
-                "job_name": "test job name",
-                "parent_id": "ZZZ",
-                "parent_name": "test parent name",
-            },
+            job_item=job_item,
             targets=["test-node1", "test-node2"],
         )
         self.assertDictEqual(
-            status,
+            status.__dict__,
             {
-                "ACCEPTED": True,
-                "INFO": {},
-                "JOB_DEFINITION": {
-                    "verb": "TEST",
-                    "job_sha3_224": "YYY",
-                    "job_name": "test job name",
-                    "parent_id": "ZZZ",
-                    "parent_name": "test parent name",
-                },
-                "_nodes": ["test-node1", "test-node2"],
+                "_createtime": ANY,
+                "_executiontime": {"test-node1": 0, "test-node2": 0},
+                "_lasttime": ANY,
+                "_processing": {"test-node1": "\x00", "test-node2": "\x00"},
+                "_roundtripltime": {"test-node1": 0, "test-node2": 0},
+                "job_id": "XXX",
+                "JOB_DEFINITION": ANY,
+                "JOB_SHA3_224": "YYY",
+                "JOB_NAME": "test job name",
                 "PARENT_JOB_ID": "ZZZ",
                 "PARENT_JOB_NAME": "test parent name",
-                "STDERR": {},
-                "STDOUT": {},
-                "JOB_NAME": "test job name",
-                "JOB_SHA3_224": "YYY",
                 "VERB": "TEST",
-                "_createtime": ANY,
-                "_processing": ANY,
-                "_executiontime": ANY,
-                "_roundtripltime": ANY,
+                "COMPONENT_TIMESTAMP": None,
+                "INFO": {"test-node1": None, "test-node2": None},
+                "PROCESSING": None,
+                "RETURN_TIMESTAMP": None,
+                "STDERR": {"test-node1": None, "test-node2": None},
+                "STDOUT": {"test-node1": None, "test-node2": None},
             },
         )
 
@@ -455,11 +380,7 @@ class TestServer(tests.TestDriverBase):
         self.server.return_jobs["XXX"] = {"exists": True}
         status = self.server.create_return_jobs(
             task="XXX",
-            job_item={
-                "verb": "TEST",
-                "job_sha3_224": "YYY",
-                "parent_id": "ZZZ",
-            },
+            job_item=self.job_item,
             targets=[b"test-node1", b"test-node2"],
         )
         self.assertDictEqual(
@@ -732,8 +653,12 @@ class TestServer(tests.TestDriverBase):
                         "test-node1",
                         {
                             "identity": "test-node1",
-                            "version": "x.x.x",
                             "expire_time": 12345,
+                            "machine_id": None,
+                            "version": "x.x.x",
+                            "host_uptime": None,
+                            "agent_uptime": None,
+                            "driver": None,
                             "expiry": 12345,
                         },
                     ],
@@ -741,35 +666,18 @@ class TestServer(tests.TestDriverBase):
                         "test-node2",
                         {
                             "identity": "test-node2",
-                            "version": "x.x.x",
                             "expire_time": 12345,
+                            "machine_id": None,
+                            "version": "x.x.x",
+                            "host_uptime": None,
+                            "agent_uptime": None,
+                            "driver": None,
                             "expiry": 12345,
                         },
                     ],
                 ]
             ).encode()
         )
-        mock_chmod.assert_called()
-        mock_chown.assert_called()
-
-    @patch("os.chown", autospec=True)
-    @patch("os.chmod", autospec=True)
-    @patch("os.unlink", autospec=True)
-    @patch("socket.socket", autospec=True)
-    def test_run_socket_server_manage_list_jobs(
-        self, mock_socket, mock_unlink, mock_chmod, mock_chown
-    ):
-        socket = mock_socket.return_value = MagicMock()
-        conn = MagicMock()
-        conn.recv.return_value = json.dumps(
-            {"manage": {"list_jobs": None}}
-        ).encode()
-        conn.sendall = MagicMock()
-        socket.accept.return_value = [conn, MagicMock()]
-        self.server.return_jobs = {"k": {"v": "test"}}
-        self.server.run_socket_server()
-        mock_unlink.assert_called_with(self.args.socket_path)
-        conn.sendall.assert_called_with(b'[["k", {"v": "test"}]]')
         mock_chmod.assert_called()
         mock_chown.assert_called()
 
@@ -846,7 +754,7 @@ class TestServer(tests.TestDriverBase):
         socket.accept.return_value = [conn, MagicMock()]
         self.server.run_socket_server()
         mock_unlink.assert_called_with(self.args.socket_path)
-        self.assertDictEqual(self.server.return_jobs, {})
+        self.assertDictEqual(self.server.return_jobs, {"XXX": ANY})
         conn.sendall.assert_called_with(b"Job received. Task ID: XXX")
         mock_chmod.assert_called()
         mock_chown.assert_called()
@@ -874,7 +782,7 @@ class TestServer(tests.TestDriverBase):
         socket.accept.return_value = [conn, MagicMock()]
         self.server.run_socket_server()
         mock_unlink.assert_called_with(self.args.socket_path)
-        self.assertDictEqual(self.server.return_jobs, {})
+        self.assertDictEqual(self.server.return_jobs, {"XXX": ANY})
         conn.sendall.assert_called_with(b"XXX")
         mock_chmod.assert_called()
         mock_chown.assert_called()

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -470,7 +470,6 @@ DEBUG Executing Management Command:list-jobs
 KEY                   VALUE
 --------------------  -------------------------------------------------------
 ID                    09a0d4aa-ff84-40e4-a7e2-88be8dff841a
-ACCEPTED              True
 STDOUT                df.next-c0.localdomain = true
 VERB                  ECHO
 JOB_SHA3_224          86823a46fb4af75c9f93c8bedb301dfa8968321a


### PR DESCRIPTION
This change moves the worker items from a hash object to a class, which
has dynamic properties to assist Directord in known the state of
workers. This will help us further enhance the worker experience and
make intellegent decisions about cluster activities when required.

Signed-off-by: Kevin Carter <kevin@cloudnull.com>