### PR TITLE
Add server side logic to mark nodes active

### DIFF
--- a/directord/datastores/__init__.py
+++ b/directord/datastores/__init__.py
@@ -23,7 +23,7 @@ class BaseDocument(dict):
 
         for key, value in list(self.items()):
             try:
-                if value.expired:
+                if value.expired and value.active:
                     self.pop(key)
             except (AttributeError, KeyError):
                 try:

--- a/directord/datastores/disc.py
+++ b/directord/datastores/disc.py
@@ -57,7 +57,7 @@ class BaseDocument(utils.Cache):
 
         for key, value in list(self.items()):
             try:
-                if value.expired:
+                if value.expired and value.active:
                     self.pop(key, None)
             except AttributeError:
                 try:

--- a/directord/interface.py
+++ b/directord/interface.py
@@ -98,6 +98,7 @@ class Worker:
         """Initialize the worker object."""
 
         self.identity = identity
+        self.active = True
         self.expire_time = None
         self.machine_id = None
         self.version = None

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -653,6 +653,7 @@ class TestServer(tests.TestDriverBase):
                         "test-node1",
                         {
                             "identity": "test-node1",
+                            "active": True,
                             "expire_time": 12345,
                             "machine_id": None,
                             "version": "x.x.x",
@@ -666,6 +667,7 @@ class TestServer(tests.TestDriverBase):
                         "test-node2",
                         {
                             "identity": "test-node2",
+                            "active": True,
                             "expire_time": 12345,
                             "machine_id": None,
                             "version": "x.x.x",


### PR DESCRIPTION
When a node is active, work will be sent, if a node is inactive no work
will be sent to the node and that node will not be removed when expired.
Upon the nodes next healthcheck, the node will be reset as active and
all queued tasks will be sent at that time.

Related-Bug: #343
Signed-off-by: Kevin Carter <kevin@cloudnull.com>