### PR TITLE
reintegrate iodict

### DIFF
--- a/contrib/container-build/builder.sh
+++ b/contrib/container-build/builder.sh
@@ -11,13 +11,6 @@ sudo chown builder: /home/builder/rpm
 echo "Creating artifact directory: ${ARTIFACT_DIR}"
 mkdir -p ${ARTIFACT_PATH}
 
-# Remove when iodict is actually packaged.
-IODICTRELEASE=$(curl --silent 'https://api.github.com/repos/directord/iodict/releases/latest' | grep '"tag_name":' |  sed -E 's/.*"([^"]+)".*/\1/')
-pushd ${ARTIFACT_PATH}
-  wget "https://github.com/directord/iodict/releases/download/${IODICTRELEASE}/iodict-${IODICTRELEASE}-1.el8.noarch.rpm"
-  sudo dnf -y install iodict-${IODICTRELEASE}-1.el8.noarch.rpm
-popd
-
 echo "Installing build deps..."
 echo "Logging to ${ARTIFACT_PATH}/builddep.log"
 sudo dnf -y builddep "${SPEC_PATH}" &> ${ARTIFACT_PATH}/builddep.log

--- a/contrib/container-build/directord.spec
+++ b/contrib/container-build/directord.spec
@@ -31,9 +31,6 @@ Requires:       python3-pyyaml
 Requires:       python3-tabulate
 Requires:       python3-tenacity
 
-# TODO(cloudnull): Change this to an actual package when it exists.
-Requires:       python3dist(iodict)
-
 # Recommends
 Recommends:       python3-ssh-python
 Recommends:       python3-zmq

--- a/directord/client.py
+++ b/directord/client.py
@@ -21,6 +21,7 @@ import time
 import directord
 from directord import components
 from directord import interface
+from directord import iodict
 from directord import utils
 
 
@@ -134,7 +135,7 @@ class Client(interface.Interface):
         if not lock:
             lock = self.driver.get_lock()
 
-        parent_tracker_recover = utils.DurableQueue(
+        parent_tracker_recover = iodict.DurableQueue(
             path=os.path.join(self.args.cache_path, "parent_tracker"),
             lock=lock,
         )
@@ -851,7 +852,7 @@ class Client(interface.Interface):
                 False,
             ),
         ]
-        self.cache = utils.Cache(
+        self.cache = iodict.Cache(
             path=os.path.join(self.args.cache_path, "client"),
             lock=self.driver.get_lock(),
         )

--- a/directord/datastores/disc.py
+++ b/directord/datastores/disc.py
@@ -16,10 +16,10 @@ import os
 import struct
 import time
 
-from directord import utils
+from directord import iodict
 
 
-class BaseDocument(utils.Cache):
+class BaseDocument(iodict.Cache):
     """Create a document store object."""
 
     def __init__(self, url):

--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -18,9 +18,9 @@ import socket
 import time
 import threading
 
+from directord import iodict
 from directord import logger
 from directord import models
-from directord import utils
 
 
 def parse_args(parser):
@@ -49,7 +49,7 @@ class ExceptionThreadProcessor(threading.Thread):
             self.exception = e
 
 
-class _FlushQueue(queue.Queue, utils.FlushQueue):
+class _FlushQueue(queue.Queue, iodict.FlushQueue):
     """Flush queue capability helper class."""
 
     def __init__(self, path, lock, semaphore):

--- a/directord/drivers/zmq.py
+++ b/directord/drivers/zmq.py
@@ -29,6 +29,7 @@ except (ImportError, ModuleNotFoundError):
     pass
 
 from directord import drivers
+from directord import iodict
 from directord import logger
 from directord import utils
 
@@ -102,7 +103,7 @@ def parse_args(parser, parser_server, parser_client):
     return parser
 
 
-class _FlushQueue(mqs.Queue, utils.FlushQueue):
+class _FlushQueue(mqs.Queue, iodict.FlushQueue):
     """Flush queue capability helper class."""
 
     def __init__(self, path, lock, semaphore):

--- a/directord/iodict.py
+++ b/directord/iodict.py
@@ -1,0 +1,572 @@
+#   Copyright Peznauts <kevin@peznauts.com>. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import multiprocessing
+import operator
+import os
+import pickle
+import queue
+import struct
+import traceback
+import time
+import typing
+
+from directord import utils
+
+
+_S = typing.TypeVar("_S")
+_T = typing.TypeVar("_T")
+_KT = typing.TypeVar("_KT")
+_VT = typing.TypeVar("_VT")
+
+
+def _get_create_time(path: str):
+    """Return the file object birthtime.
+
+    :param path: Storage path
+    :type path: String
+    :returns: Float
+    """
+    try:
+        birthtime = os.getxattr(path, "user.birthtime")
+        return struct.unpack(">d", birthtime)[0]
+    except OSError:
+        stat = os.stat(path)
+        try:
+            return stat.st_birthtime
+        except AttributeError:
+            return stat.st_ctime
+
+
+def _get_item_key(path: str):
+    """Return the key name from a file object.
+
+    :returns: String
+    """
+    try:
+        key = os.getxattr(path, "user.key")
+    except OSError:
+        if not os.path.exists(path):
+            raise FileNotFoundError(path) from None
+        return os.path.basename(path)
+    else:
+        return key.decode()
+
+
+def _makedirs(path: str, key: _KT = None):
+    """Create a directory and set attributes."""
+    try:
+        os.makedirs(path, exist_ok=True)
+    except FileExistsError:
+        os.unlink(path)
+        os.makedirs(path, exist_ok=True)
+
+    _setxattr(path=path, key=key)
+
+
+def _setxattr(path: str, key: _KT = None):
+    """Set file object attributes.
+
+    :param path: File path
+    :type path: String
+    :param key: Key information
+    :type key: String
+    :returns: Boolean
+    """
+    try:
+        try:
+            os.getxattr(path, "user.birthtime")
+        except OSError:
+            os.setxattr(
+                path,
+                "user.birthtime",
+                struct.pack(">d", time.time()),
+            )
+    except OSError:
+        pass
+    else:
+        if key:
+            os.setxattr(path, "user.key", key.encode())
+
+
+class BaseClass:
+    """Base class for the iodict library."""
+
+    def __exit__(
+        self, exc_type: typing.Any, exc_value: typing.Any, tb: typing.Any
+    ):
+        """Exit and return boolean.
+
+        :returns: Boolean
+        """
+        if exc_type is not None:
+            traceback.print_exception(exc_type, exc_value, tb)
+            return False
+
+        return True
+
+
+class BaseQueue:
+    def getter(self):
+        """Yield items from the queue until empty."""
+
+        while True:
+            try:
+                item = self.get_nowait()
+            except Exception:
+                break
+            else:
+                yield item
+
+
+class IODict(BaseClass):
+    def __init__(self, path: str, lock: typing.Any = None):
+        """Initialize the POSIX compatible datastore.
+
+        The POSIX cache store uses xattrs to store metadata about stored
+        objects. Metadata is used to store the key and expiry information
+        which is used to ensure we're maintaining a POSIX compliant data
+        store which leverages simple file hashing. If xattrs are not
+        availble on the filesystem, the cache method will fallback to a
+        standard string encoding, and rely on in file information for
+        expiry times.
+
+        > If a lock object is not provided, a multiprocessing lock will
+          be used.
+
+        :param path: Storage path
+        :type path: String
+        :param lock: Lock type object
+        :type lock: Object
+        """
+        if not lock:
+            lock = multiprocessing.Lock()
+
+        self._lock = lock
+        self._db_path = os.path.abspath(os.path.expanduser(path))
+        _makedirs(path=self._db_path)
+        try:
+            os.listxattr(self._db_path)
+        except Exception:
+            self._encoder = str
+        else:
+            self._encoder = utils.object_sha3_224
+
+    def __delitem__(self, key: _KT):
+        """Delete an item from the datastore.
+
+        :param key: Named object.
+        :type key: Object
+        """
+        item = os.path.join(self._db_path, self._encoder(key))
+        with self._lock:
+            try:
+                os.unlink(item)
+            except FileNotFoundError:
+                raise KeyError(key) from None
+
+    def __enter__(self):
+        """Contect manager enter object.
+
+        Entering the context manager will return itself.
+
+        :returns: Object
+        """
+        return self
+
+    def __exit__(
+        self, exc_type: typing.Any, exc_value: typing.Any, tb: typing.Any
+    ):
+        """Clean up the dictionary and exit the context manager.
+
+        :returns: Boolean
+        """
+        try:
+            self.clear()
+        finally:
+            return super().__exit__(exc_type, exc_value, tb)
+
+    def __getitem__(self, key: _KT):
+        """Return the value of a given key.
+
+        If a given key is not found, get will raise a KeyError exception.
+
+        :param key: Named object.
+        :type key: Object
+        :returns: Object
+        """
+        file_object = os.path.join(self._db_path, self._encoder(key))
+        with self._lock:
+            try:
+                with open(file_object, "rb") as f:
+                    return pickle.load(f)
+            except FileNotFoundError:
+                raise KeyError(key) from None
+
+    def __iter__(self, index: int = None):
+        """Iterate over the keys and Yield.
+
+        :param index: Index number to start from.
+        :type index: Integer
+        :returns: List || :yield: Object
+        """
+        items = list()
+        if not os.path.exists(self._db_path):
+            return items
+
+        for item in os.scandir(self._db_path):
+            try:
+                items.append(
+                    (
+                        _get_item_key(item.path),
+                        _get_create_time(item.path),
+                        item.path,
+                    )
+                )
+            except FileNotFoundError:
+                pass
+
+        items = sorted(items, key=operator.itemgetter(1))
+        if not items:
+            return list()
+        elif index is not None and isinstance(index, int):
+            if not os.path.exists(items[index][-1]):
+                yield next(self.__iter__(index=index))
+            else:
+                yield items[index][0]
+        else:
+            for item in items:
+                try:
+                    if not os.path.exists(item[-1]):
+                        continue
+                    yield item[0]
+                except GeneratorExit:
+                    pass
+
+    def __len__(self):
+        """Return a count of all keys in the datastore.
+
+        :returns: Integer
+        """
+        count = 0
+        for _ in self.__iter__():
+            count += 1
+        return count
+
+    def __repr__(self):
+        """Returns repr string."""
+        return str(dict(self.items()))
+
+    def __setitem__(self, key: _KT, value: _VT):
+        """Set an item in the datastore.
+
+        > objects are serialized. Files use xattrs to store meta-data which
+          is used to enhance operations.
+
+        :param key: Named object to set.
+        :type key: Object
+        :param value: Object to set.
+        :type value: Object
+        """
+        file_object = os.path.join(self._db_path, self._encoder(key))
+        with self._lock:
+            with open(file_object, "wb") as f:
+                pickle.dump(value, f)
+
+            _setxattr(path=file_object, key=key)
+
+    def clear(self):
+        """Remove all cache."""
+        for item in self.__iter__():
+            self.__delitem__(item)
+
+    def copy(self):
+        """Return self.
+
+        :returns: Object
+        """
+        return self
+
+    def get(self, key: _KT, default: typing.Any = None):
+        """Return the value of a given key.
+
+        :param key: Named object.
+        :type key: Object
+        :param default: Default return.
+        :type default: Object
+        :returns: Object
+        """
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            return default
+
+    def fromkeys(self, iterable: typing.Iterable[_T], value: _S = None):
+        """Set a list of items using a default.
+
+        :param iterable: Iterable object to add to the data-store.
+        :type iterable: Iterable
+        """
+        for item in iterable:
+            self.__setitem__(item, value)
+
+    def items(self):
+        """Iterate through all items and yield a tuples, for key and value.
+
+        :yields: Tuple
+        """
+        for item in self.keys():
+            yield item, self.__getitem__(item)
+
+    def keys(self):
+        """Return an array of all keys.
+
+        :yields: item || :returns: List
+        """
+        for item in self.__iter__():
+            yield item
+
+    def pop(self, key: _KT, default: typing.Any = None):
+        """Remove a given key from the cache.
+
+        :param key: Named object.
+        :type key: Object
+        :param default: Default return.
+        :type default: Object
+        :returns: Object
+        """
+        try:
+            try:
+                return self.__getitem__(key)
+            finally:
+                self.__delitem__(key)
+        except KeyError as e:
+            if default:
+                return default
+            else:
+                raise e
+
+    def popitem(self):
+        """Remove and return an item from the datastore.
+
+        :returns: Object
+        """
+        try:
+            return self.pop(next(self.__iter__(index=0)))
+        except (IndexError, StopIteration):
+            raise KeyError("popitem(): dictionary is empty") from None
+
+    def setdefault(self, key: _KT, default: typing.Any = None):
+        """Return the value of a given key.
+
+        :param key: Named object.
+        :type key: Object
+        :param default: Default return.
+        :type default: Object
+        :returns: Object
+        """
+        self.__setitem__(key, default)
+        return default
+
+    def update(self, mapping: typing.Mapping[_KT, _VT]):
+        """Update the datastore with a new mapping.
+
+        :param mapping: Map object, assumes a call to items.
+        :type mapping: Mapping
+        """
+        for k, v in mapping.items():
+            self.__setitem__(k, v)
+
+    def values(self):
+        """Return an array of all values.
+
+        :yields: item || :returns: List
+        """
+        for item in self.__iter__():
+            yield self.__getitem__(item)
+
+
+class DurableQueue(BaseQueue):
+    """DurableQueue class, used to ensure queued items are disk backed.
+
+    This implements the standard Queue API, allowing the user to replace
+    queue.Queue or mulriprocessing.Queue with a DurableQueue.
+
+    DurableQueue is IODict backed.
+    """
+
+    def __init__(
+        self, path: str, lock: typing.Any = None, semaphore: typing.Any = None
+    ):
+        """Initiallize the DurableQueue class.
+
+        Durable queues use a semephore to keep track of the puts vs gets. When
+        a Durable queue is loaded, it will scan the queue for items, and set
+        the initial `_count` accordingly.
+
+        :param path: Storage path
+        :type path: String
+        :param lock: Lock type object
+        :type lock: Object
+        :param semaphore: Semaphore type object
+        :type semaphore: Object
+        """
+
+        if not semaphore:
+            semaphore = multiprocessing.Semaphore
+
+        self._queue = IODict(path=path, lock=lock)
+
+        self._count = semaphore(self.qsize())
+
+    def close(self):
+        """Close the current Queue and cleanup artifacts."""
+
+        try:
+            self._queue.clear()
+            os.rmdir(self._queue._db_path)
+        except FileNotFoundError:
+            pass
+
+    def empty(self):
+        """Return True if the queue is empty, False otherwise.
+
+        :returns: Boolean
+        """
+
+        return self.qsize() == 0
+
+    def get(self, block: bool = True, timeout: float = None):
+        """Retrieve the first item from the queue.
+
+        :param block: Force the queue to block attempting to fetch an object.
+        :type block: Boolean
+        :param timeout: Set the block timeout
+        :type timeout: Float
+        :returns: Object
+        """
+
+        if timeout is not None and timeout < 0:
+            raise ValueError("timeout must be non-negative")
+
+        if not self._count.acquire(block, timeout):
+            raise queue.Empty
+
+        return self._queue.popitem()
+
+    def get_nowait(self):
+        """Retrieve the first item from the queue without blocking.
+
+        :returns: Object
+        """
+
+        return self.get(block=False)
+
+    def put(self, item: typing.Any, block: bool = True, timeout: float = None):
+        """Put a new item within the queue.
+
+        > The block and timeout options are present for API compatibility,
+          but are otherwise unused.
+
+        :param item: Object to be entered into the queue.
+        :type item: Object
+        :param block: Force the queue to block attempting to fetch an object.
+        :type block: Boolean
+        :param timeout: Set the block timeout
+        :type timeout: Float
+        """
+
+        self._queue[utils.get_uuid()] = item
+        self._count.release()
+
+    def put_nowait(self, item: typing.Any):
+        """Put a new item within the queue without blocking.
+
+        :param item: Object to be entered into the queue.
+        :type item: Object
+        """
+
+        self.put(item)
+
+    def qsize(self):
+        """Return the approximate size of the queue.
+
+        :returns: Integer
+        """
+
+        try:
+            return len(self._queue)
+        except FileNotFoundError:
+            return 0
+
+
+class FlushQueue(BaseQueue):
+    def __init__(self, path, lock=None, semaphore=None):
+        """Queue class augmentation allowing queues to be flushed to disk.
+
+        This class requires a queue class to be used along with it.
+
+        >>> class _FlushQueue(queue.Queue, FlushQueue):
+        ...     def __init__(self, path, lock, semaphore):
+        ...         super().__init__()
+        ...         self.path = path
+        ...         self.lock = lock
+        ...         self.semaphore = semaphore
+
+        With multiple inheritence, we can create any queue object with flush
+        capabilities.
+        """
+
+        self.path = path
+        self.lock = lock
+        self.semaphore = semaphore
+
+    def flush(self):
+        """Flush all remaining items in queue to disk."""
+
+        durable = DurableQueue(
+            path=self.path, lock=self.lock, semaphore=self.semaphore
+        )
+        while True:
+            try:
+                item = self.get_nowait()
+            except Exception:
+                break
+            else:
+                durable.put(item)
+
+    def ingest(self):
+        """Check for existing items in queue and restore them."""
+
+        if not os.path.exists(self.path):
+            return
+
+        durable = DurableQueue(
+            path=self.path, lock=self.lock, semaphore=self.semaphore
+        )
+        while True:
+            try:
+                item = durable.get_nowait()
+            except Exception:
+                break
+            else:
+                self.put(item)
+
+        durable.close()
+
+
+class Cache(IODict):
+    """Helper class to create the Cache object."""
+
+    pass

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from directord import drivers
-from directord import utils
+from directord import iodict
 
 
 tracemalloc.start()
@@ -108,13 +108,14 @@ class FakePopen:
 
 
 class FakeStat:
-    def __init__(self, uid, gid):
+    def __init__(self, uid=0, gid=0):
         self.st_uid = uid
         self.st_gid = gid
         self.st_size = 0
         self.st_mtime = 0
         self.st_mode = 0
         self.st_atime = 0
+        self.st_ctime = 1.0
 
 
 class FakeArgs:
@@ -176,7 +177,7 @@ class MockSocket:
         pass
 
 
-class MockQueue(queue.Queue, utils.BaseQueue):
+class MockQueue(queue.Queue, iodict.BaseQueue):
 
     pass
 
@@ -282,7 +283,7 @@ class TestDriverBase(TestBase):
         super().setUp()
         base_driver = drivers.BaseDriver(args=FakeArgs())
         self.patched_get_queue = patch(
-            "directord.utils.DurableQueue", autospec=True
+            "directord.iodict.DurableQueue", autospec=True
         )
         self.mock_driver_patched = patch(
             "directord.drivers.BaseDriver",

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -44,7 +44,7 @@ class TestComponents(tests.TestBase):
             self.client = client.Client(args=self.args)
 
         self.patched_get_queue = patch(
-            "directord.utils.DurableQueue", autospec=True
+            "directord.iodict.DurableQueue", autospec=True
         )
         self.patched_get_queue.start()
         self.patched_get_queue.return_value = tests.FakeQueue()

--- a/directord/tests/test_iodict.py
+++ b/directord/tests/test_iodict.py
@@ -1,0 +1,725 @@
+#   Copyright Peznauts <kevin@peznauts.com>. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import pickle
+import queue
+import unittest
+
+from unittest.mock import call
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from directord import iodict
+from directord import tests
+from directord import utils
+
+
+class MockItem:
+    def __init__(self, path):
+        self.path = path
+
+
+class BaseTest(unittest.TestCase):
+    def setUp(self):
+        self.patched_makedirs = patch("os.makedirs", autospec=True)
+        self.mock_makedirs = self.patched_makedirs.start()
+        self.patched_stat = patch("os.stat", autospec=True)
+        mock_stat = self.patched_stat.start()
+        mock_stat.return_value = tests.FakeStat()
+
+    def tearDown(self):
+        self.patched_makedirs.stop()
+        self.patched_stat.stop()
+
+
+class TestIODict(BaseTest):
+    def test_base___exit__(self):
+        e = iodict.BaseClass()
+        exit_value = e.__exit__(None, None, None)
+        self.assertTrue(exit_value)
+
+    @patch("traceback.print_exception", autospec=True)
+    def test_base___exit__error(self, mock_print_exception):
+        e = iodict.BaseClass()
+        exit_value = e.__exit__(Exception, Exception, None)
+        self.assertFalse(exit_value)
+        mock_print_exception.assert_called()
+
+    def test_init_no_lock(self):
+        import multiprocessing
+
+        d = iodict.IODict(path="/not/a/path")
+        self.mock_makedirs.assert_called_with("/not/a/path", exist_ok=True)
+        assert isinstance(d._lock, multiprocessing.synchronize.Lock)
+
+    def test_init_thread_lock(self):
+        import threading
+        import _thread
+
+        d = iodict.IODict(path="/not/a/path", lock=threading.Lock())
+        self.mock_makedirs.assert_called_with("/not/a/path", exist_ok=True)
+        assert isinstance(d._lock, _thread.LockType)
+
+    @patch("os.listxattr", autospec=True)
+    def test_init_xattr(self, mock_listxattr):
+        mock_listxattr.return_value = ["user.birthtime"]
+        d = iodict.IODict(path="/not/a/path")
+        mock_listxattr.assert_called()
+        assert d._encoder == utils.object_sha3_224
+
+    @patch("os.listxattr", autospec=True)
+    def test_init_no_xattr(self, mock_listxattr):
+        mock_listxattr.side_effect = OSError("error")
+        d = iodict.IODict(path="/not/a/path")
+        assert d._encoder == str
+
+    @patch("os.listxattr", autospec=True)
+    @patch("os.unlink", autospec=True)
+    def test__delitem___(self, mock_unlink, mock_listxattr):
+        d = iodict.IODict(path="/not/a/path")
+        d.__delitem__("not-an-item")
+        mock_unlink.assert_called_with(
+            "/not/a/path/9139d70ac1859518deb6c9adb589348b8e5b00b9b6acffdb4ee6443d"
+        )
+
+    @patch("os.unlink", autospec=True)
+    def test__delitem___no_xattr(self, mock_unlink):
+        d = iodict.IODict(path="/not/a/path")
+        d.__delitem__("not-an-item")
+        mock_unlink.assert_called_with("/not/a/path/not-an-item")
+
+    @patch("os.unlink", autospec=True)
+    def test__delitem__missing(self, mock_unlink):
+        mock_unlink.side_effect = FileNotFoundError
+        d = iodict.IODict(path="/not/a/path")
+        with self.assertRaises(KeyError):
+            d.__delitem__("not-an-item")
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.listxattr", autospec=True)
+    def test__exit__(self, mock_listxattr, mock_scandir):
+        with patch("builtins.open", unittest.mock.mock_open()):
+            with patch.object(
+                iodict.IODict, "clear", autospec=True
+            ) as mock_clear:
+                with iodict.IODict(path="/not/a/path") as d:
+                    d["not-an-item"] = {"a": 1}
+
+            self.assertFalse(d)
+            mock_clear.assert_called()
+
+    def test__getitem__(self):
+        read_data = pickle.dumps({"a": 1})
+        d = iodict.IODict(path="/not/a/path")
+        with patch(
+            "builtins.open", unittest.mock.mock_open(read_data=read_data)
+        ):
+            item = d.__getitem__("not-an-item")
+        self.assertEqual(item, {"a": 1})
+
+    def test__getitem__missing(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch("builtins.open", unittest.mock.mock_open()) as mock_f:
+            mock_f.side_effect = FileNotFoundError
+            with self.assertRaises(KeyError):
+                d.__getitem__("not-an-item")
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.path.exists", autospec=True)
+    @patch("os.getcwd", autospec=True)
+    @patch("os.chdir", autospec=True)
+    def test__iter__(self, mock_chdir, mock_getcwd, mock_exists, mock_scandir):
+        mock_getcwd.return_value = "/"
+        mock_exists.return_value = True
+        mock_scandir.return_value = [MockItem("file1"), MockItem("file2")]
+        d = iodict.IODict(path="/not/a/path")
+        with patch("os.getxattr") as mock_getxattr:
+            mock_getxattr.side_effect = [
+                b"key1",
+                b"A\xd8kl\xc1\xb1\xd9]",
+                b"key2",
+                b"A\xd8kn\x0f}\xda\x16",
+            ]
+            return_items = [i for i in d.__iter__()]
+            self.assertEqual(return_items, ["key1", "key2"])
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.path.exists", autospec=True)
+    @patch("os.getcwd", autospec=True)
+    @patch("os.chdir", autospec=True)
+    def test__iter__not_found(
+        self, mock_chdir, mock_getcwd, mock_exists, mock_scandir
+    ):
+        mock_getcwd.return_value = "/"
+        mock_exists.return_value = True
+        mock_scandir.return_value = [MockItem("file1")]
+        d = iodict.IODict(path="/not/a/path")
+        with patch("os.getxattr") as mock_getxattr:
+            mock_getxattr.side_effect = [
+                b"key1",
+                b"A\xd8kn\x0f}\xda\x16",
+                FileNotFoundError,
+            ]
+            return_items = [i for i in d.__iter__()]
+            self.assertEqual(return_items, ["key1"])
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.path.exists", autospec=True)
+    @patch("os.getcwd", autospec=True)
+    @patch("os.chdir", autospec=True)
+    def test__iter__no_xattr(
+        self,
+        mock_chdir,
+        mock_getcwd,
+        mock_exists,
+        mock_scandir,
+    ):
+        mock_getcwd.return_value = "/"
+        mock_exists.return_value = True
+        mock_scandir.return_value = [
+            MockItem("key1"),
+            MockItem("key2"),
+        ]
+        d = iodict.IODict(path="/not/a/path")
+        with patch("os.getxattr") as mock_getxattr:
+            mock_getxattr.side_effect = OSError
+            return_items = [i for i in d.__iter__()]
+            self.assertEqual(return_items, ["key1", "key2"])
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.path.exists", autospec=True)
+    @patch("os.getcwd", autospec=True)
+    @patch("os.chdir", autospec=True)
+    def test__iter__index(
+        self, mock_chdir, mock_getcwd, mock_exists, mock_scandir
+    ):
+        mock_getcwd.return_value = "/"
+        mock_exists.return_value = True
+        mock_scandir.return_value = [MockItem("file1"), MockItem("file2")]
+        d = iodict.IODict(path="/not/a/path")
+        with patch("os.getxattr") as mock_getxattr:
+            mock_getxattr.side_effect = [
+                b"key1",
+                b"A\xd8kn\x0f}\xda\x16",
+                b"key2",
+                b"A\xd8kl\xc1\xb1\xd9]",
+            ]
+            self.assertEqual([i for i in d.__iter__(index=1)], ["key1"])
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.path.exists", autospec=True)
+    @patch("os.getcwd", autospec=True)
+    @patch("os.chdir", autospec=True)
+    def test__iter__no_items(
+        self, mock_chdir, mock_getcwd, mock_exists, mock_scandir
+    ):
+        mock_getcwd.return_value = "/"
+        mock_exists.return_value = True
+        mock_scandir.return_value = []
+        d = iodict.IODict(path="/not/a/path")
+        self.assertEqual([i for i in d.__iter__()], [])
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.path.exists", autospec=True)
+    def test__iter__no_exist(self, mock_exists, mock_scandir):
+        mock_exists.side_effect = [True, True, False, True, True]
+        mock_scandir.return_value = [
+            MockItem("file1"),
+            MockItem("file2"),
+            MockItem("file3"),
+        ]
+        d = iodict.IODict(path="/not/a/path")
+        with patch("os.getxattr") as mock_getxattr:
+            mock_getxattr.side_effect = [
+                b"key1",
+                b"A\xd8kn\x0f}\xda\x16",
+                FileNotFoundError,
+                FileNotFoundError,
+                b"key3",
+                b"A\xd8kl\xc1\xb1\xd9]",
+            ]
+            self.assertEqual([i for i in d.__iter__()], ["key3", "key1"])
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.path.exists", autospec=True)
+    def test__iter__exist_no_exist(self, mock_exists, mock_scandir):
+        mock_exists.side_effect = [True, True, False, False]
+        mock_scandir.return_value = [
+            MockItem("file1"),
+            MockItem("file2"),
+            MockItem("file3"),
+        ]
+        d = iodict.IODict(path="/not/a/path")
+        with patch("os.getxattr") as mock_getxattr:
+            mock_getxattr.side_effect = [
+                b"key1",
+                b"A\xd8kn\x0f}\xda\x16",
+                b"key2",
+                b"A\xd8kl\xc1\xb1\xd9]",
+                b"key3",
+                b"A\xd8kl\xc1\xb1\xd9]",
+            ]
+            self.assertEqual([i for i in d.__iter__()], ["key2"])
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.path.exists", autospec=True)
+    def test__iter__reindex(self, mock_exists, mock_scandir):
+        mock_exists.side_effect = [True, False, True, True]
+        mock_scandir.side_effect = [
+            [MockItem("file1"), MockItem("file2")],
+            [MockItem("file2")],
+        ]
+        d = iodict.IODict(path="/not/a/path")
+        with patch("os.getxattr") as mock_getxattr:
+            mock_getxattr.side_effect = [
+                b"key1",
+                b"A\xd8kn\x0f}\xda\x16",
+                b"key2",
+                b"A\xd8kl\xc1\xb1\xd9]",
+                b"key2",
+                b"A\xd8kl\xc1\xb1\xd9]",
+            ]
+            self.assertEqual([i for i in d.__iter__(index=0)], ["key2"])
+
+    @patch("os.scandir", autospec=True)
+    @patch("os.path.exists", autospec=True)
+    def test__iter__generatorexit(self, mock_exists, mock_scandir):
+        mock_exists.side_effect = [True, True, GeneratorExit]
+        mock_scandir.return_value = [MockItem("file1"), MockItem("file2")]
+        d = iodict.IODict(path="/not/a/path")
+        with patch("os.getxattr") as mock_getxattr:
+            mock_getxattr.side_effect = [
+                b"key1",
+                b"A\xd8kl\xc1\xb1\xd9]",
+                b"key2",
+                b"A\xd8kn\x0f}\xda\x16",
+            ]
+            return_items = [i for i in d.__iter__()]
+            self.assertEqual(return_items, ["key1"])
+
+    @patch("os.scandir", autospec=True)
+    def test__len__zero(self, mock_scandir):
+        mock_scandir.return_value = []
+        d = iodict.IODict(path="/not/a/path")
+        self.assertEqual(len(d), 0)
+
+    def test__len__(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__iter__", autospec=True) as mock__iter__:
+            mock__iter__.return_value = ["file1", "file2"]
+            self.assertEqual(len(d), 2)
+
+    @patch("os.setxattr", autospec=True)
+    @patch("os.getxattr", autospec=True)
+    @patch("os.listxattr", autospec=True)
+    def test__setitem__(self, mock_listxattr, mock_getxattr, mock_setxattr):
+        read_data = pickle.dumps({"a": 1})
+        d = iodict.IODict(path="/not/a/path")
+        with patch(
+            "builtins.open", unittest.mock.mock_open(read_data=read_data)
+        ):
+            d.__setitem__("not-an-item", {"a": 1})
+        mock_listxattr.assert_called_with("/not/a/path")
+        mock_getxattr.assert_called_with(
+            "/not/a/path/9139d70ac1859518deb6c9adb589348b8e5b00b9b6acffdb4ee6443d",
+            "user.birthtime",
+        )
+        mock_setxattr.assert_called_with(
+            "/not/a/path/9139d70ac1859518deb6c9adb589348b8e5b00b9b6acffdb4ee6443d",
+            "user.key",
+            b"not-an-item",
+        )
+
+    @patch("os.getxattr", autospec=True)
+    def test__setitem__no_xattrs(self, mock_getxattr):
+        mock_getxattr.side_effect = OSError
+        read_data = pickle.dumps({"a": 1})
+        d = iodict.IODict(path="/not/a/path")
+        with patch(
+            "builtins.open", unittest.mock.mock_open(read_data=read_data)
+        ):
+            d.__setitem__("not-an-item", {"a": 1})
+
+    def test_clear(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__iter__", autospec=True) as mock__iter__:
+            mock__iter__.return_value = ["file1", "file2"]
+            with patch.object(
+                d, "__delitem__", autospec=True
+            ) as mock__delitem__:
+                d.clear()
+                mock__delitem__.assert_has_calls(
+                    [call("file1"), call("file2")]
+                )
+
+    def test_copy(self):
+        d = iodict.IODict(path="/not/a/path")
+        self.assertEqual(d.copy(), d)
+
+    def test_get(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__getitem__", autospec=True) as mock__getitem__:
+            mock__getitem__.return_value = "value"
+            self.assertEqual(d.get("file1"), "value")
+
+    def test_get_default(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__getitem__", autospec=True) as mock__getitem__:
+            mock__getitem__.side_effect = KeyError
+            self.assertEqual(d.get("file1", "default"), "default")
+
+    @patch("os.path.exists", autospec=True)
+    @patch("os.getxattr", autospec=True)
+    def test__get_item_key(self, mock_getxattr, mock_exists):
+        mock_getxattr.side_effect = [b"key1"]
+        mock_exists.return_value = True
+        keyname = iodict._get_item_key("/not/a/path")
+        self.assertEqual(keyname, "key1")
+
+    @patch("os.path.exists", autospec=True)
+    @patch("os.getxattr", autospec=True)
+    def test__get_item_key_unicode(self, mock_getxattr, mock_exists):
+        mock_getxattr.side_effect = OSError
+        mock_exists.return_value = True
+        keyname = iodict._get_item_key("/not/a/gAR9lC4=")
+        self.assertEqual(keyname, {})
+
+    @patch("os.path.exists", autospec=True)
+    @patch("os.getxattr", autospec=True)
+    def test__get_item_key_unicode(self, mock_getxattr, mock_exists):
+        mock_getxattr.side_effect = OSError
+        mock_exists.return_value = False
+        with self.assertRaises(FileNotFoundError):
+            iodict._get_item_key("/not/a/gAR9lC4=")
+
+    def test_fromkeys(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__setitem__", autospec=True) as mock__setitem__:
+            d.fromkeys(["file1", "file2"])
+            mock__setitem__.assert_has_calls(
+                [call("file1", None), call("file2", None)]
+            )
+
+    def test_fromkeys_default(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__setitem__", autospec=True) as mock__setitem__:
+            d.fromkeys(["file1", "file2"], "testing")
+            mock__setitem__.assert_has_calls(
+                [call("file1", "testing"), call("file2", "testing")]
+            )
+
+    def test_items(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__iter__", autospec=True) as mock__iter__:
+            mock__iter__.return_value = ["file1", "file2"]
+            with patch.object(
+                d, "__getitem__", autospec=True
+            ) as mock__getitem__:
+                mock__getitem__.side_effect = ["value1", "value2"]
+                return_items = [i for i in d.items()]
+        self.assertEqual(
+            return_items, [("file1", "value1"), ("file2", "value2")]
+        )
+
+    def test_keys(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__iter__", autospec=True) as mock__iter__:
+            mock__iter__.return_value = ["file1", "file2"]
+            return_items = [i for i in d.keys()]
+
+        self.assertEqual(return_items, ["file1", "file2"])
+
+    @patch("os.setxattr", autospec=True)
+    def test__makedirs(self, mock_setxattr):
+        iodict._makedirs("/not/a/path")
+        self.mock_makedirs.assert_called_with("/not/a/path", exist_ok=True)
+
+    @patch("os.setxattr", autospec=True)
+    def test__makedirs_key(self, mock_setxattr):
+        iodict._makedirs("/not/a/path", key="things")
+        self.mock_makedirs.assert_called_with("/not/a/path", exist_ok=True)
+        mock_setxattr.assert_called_with(
+            "/not/a/path", "user.key", "things".encode()
+        )
+
+    @patch("os.setxattr", autospec=True)
+    @patch("os.unlink", autospec=True)
+    def test__makedirs_file_exists(self, mock_unlink, mock_setxattr):
+        self.mock_makedirs.side_effect = [FileExistsError, True]
+        iodict._makedirs("/not/a/path", key="things")
+        self.mock_makedirs.assert_called_with("/not/a/path", exist_ok=True)
+        mock_setxattr.assert_called_with(
+            "/not/a/path", "user.key", "things".encode()
+        )
+        mock_unlink.assert_called_with("/not/a/path")
+
+    def test_pop(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__getitem__", autospec=True) as mock__getitem__:
+            mock__getitem__.return_value = "value"
+            with patch.object(
+                d, "__delitem__", autospec=True
+            ) as mock__delitem__:
+                self.assertEqual(d.pop("file1"), "value")
+                mock__delitem__.assert_called_with("file1")
+
+    def test_pop_default(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__getitem__", autospec=True) as mock__getitem__:
+            mock__getitem__.side_effect = KeyError
+            with patch.object(
+                d, "__delitem__", autospec=True
+            ) as mock__delitem__:
+                self.assertEqual(d.pop("file1", "default1"), "default1")
+                mock__delitem__.assert_called_with("file1")
+
+    def test_pop_no_default_keyerror(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__getitem__", autospec=True) as mock__getitem__:
+            mock__getitem__.side_effect = KeyError
+            with patch.object(
+                d, "__delitem__", autospec=True
+            ) as mock__delitem__:
+                with self.assertRaises(KeyError):
+                    d.pop("file1")
+                mock__delitem__.assert_called_with("file1")
+
+    def test_popitem(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__getitem__", autospec=True):
+            with patch.object(d, "__delitem__", autospec=True):
+                with patch.object(
+                    d, "__iter__", autospec=True
+                ) as mock__iter__:
+                    mock__iter__.return_value = iter(["file1", "file2"])
+                    with patch.object(d, "pop", autospec=True) as mock_pop:
+                        mock_pop.side_effect = ["value1", "value2"]
+                        item_value = d.popitem()
+
+        self.assertEqual(item_value, "value1")
+
+    def test_popitem(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__getitem__", autospec=True):
+            with patch.object(d, "__delitem__", autospec=True):
+                with patch.object(
+                    d, "__iter__", autospec=True
+                ) as mock__iter__:
+                    mock__iter__.return_value = iter(["file1", "file2"])
+                    with patch.object(d, "pop", autospec=True) as mock_pop:
+                        mock_pop.side_effect = StopIteration
+                        with self.assertRaises(KeyError):
+                            d.popitem()
+
+    @patch("os.scandir", autospec=True)
+    def test_repr(self, mock_scandir):
+        d = iodict.IODict(path="/not/a/path")
+        self.assertEqual(d.__repr__(), "{}")
+
+    def test_setdefault(self):
+        read_data = pickle.dumps("")
+        d = iodict.IODict(path="/not/a/path")
+        with patch(
+            "builtins.open", unittest.mock.mock_open(read_data=read_data)
+        ):
+            item = d.setdefault("not-an-item")
+
+        self.assertEqual(item, None)
+
+    def test_setdefault_default(self):
+        read_data = pickle.dumps({"a": 1})
+        d = iodict.IODict(path="/not/a/path")
+        with patch(
+            "builtins.open", unittest.mock.mock_open(read_data=read_data)
+        ):
+            item = d.setdefault("not-an-item", {"a": 1})
+
+        self.assertEqual(item, {"a": 1})
+
+    def test_update(self):
+        mapping = {"a": 1, "b": 2, "c": 3}
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__setitem__", autospec=True) as mock__setitem__:
+            d.update(mapping)
+        mock__setitem__.assert_has_calls(
+            [call("a", 1), call("b", 2), call("c", 3)]
+        )
+
+    def test_values(self):
+        d = iodict.IODict(path="/not/a/path")
+        with patch.object(d, "__iter__", autospec=True) as mock__iter__:
+            mock__iter__.return_value = ["file1", "file2"]
+            with patch.object(
+                d, "__getitem__", autospec=True
+            ) as mock__getitem__:
+                mock__getitem__.side_effect = ["value1", "value2"]
+                return_items = [i for i in d.values()]
+
+        self.assertEqual(return_items, ["value1", "value2"])
+
+
+class TestDurableQueue(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.patched_iodict = patch("directord.iodict.IODict", autospec=True)
+        self.mock_iodict = self.patched_iodict.start()
+        self.m = self.mock_iodict.return_value = MagicMock()
+        self.m._db_path = "/not/a/path"
+
+    def tearDown(self):
+        super().tearDown()
+        self.patched_iodict.stop()
+
+    def test_close(self):
+        q = iodict.DurableQueue(path="/not/a/path")
+        with patch("os.rmdir") as mock_rmdir:
+            q.close()
+
+    def test_close_missing(self):
+        q = iodict.DurableQueue(path="/not/a/path")
+        with patch("os.rmdir") as mock_rmdir:
+            mock_rmdir.side_effect = FileNotFoundError
+            q.close()
+
+    def test_empty(self):
+        q = iodict.DurableQueue(path="/not/a/path")
+        self.assertEqual(q.empty(), True)
+        with patch.object(self.m, "__len__", autospec=True):
+            self.assertEqual(q.empty(), False)
+
+    def test_get_negative_timeout(self):
+        q = iodict.DurableQueue(path="/not/a/path")
+        with self.assertRaises(ValueError):
+            q.get(timeout=-1)
+
+    def test_get_timeout(self):
+        q = iodict.DurableQueue(path="/not/a/path")
+        with self.assertRaises(queue.Empty):
+            q.get(timeout=0.1)
+
+    def test_get(self):
+        with patch.object(self.m, "__len__", autospec=True) as mock_len:
+            mock_len.return_value = 1
+            q = iodict.DurableQueue(path="/not/a/path")
+            with patch.object(
+                q._count, "acquire", autospec=True
+            ) as mock_acquire:
+                with patch.object(
+                    q._queue, "popitem", autospec=True
+                ) as mock_popitem:
+                    mock_popitem.return_value = "test"
+                    self.assertEqual(q.get(), "test")
+                    mock_acquire.assert_called_with(True, None)
+
+    def test_getnowait(self):
+        with patch.object(self.m, "__len__", autospec=True) as mock_len:
+            mock_len.return_value = 1
+            q = iodict.DurableQueue(path="/not/a/path")
+            with patch.object(
+                q._count, "acquire", autospec=True
+            ) as mock_acquire:
+                with patch.object(
+                    q._queue, "popitem", autospec=True
+                ) as mock_popitem:
+                    mock_popitem.return_value = "test"
+                    self.assertEqual(q.get_nowait(), "test")
+                    mock_acquire.assert_called_with(False, None)
+
+    def test_put(self):
+        q = iodict.DurableQueue(path="/not/a/path")
+        with patch.object(self.m, "_queue", autospec=True) as mock__queue:
+            mock__queue.return_value = dict()
+            with patch("builtins.open", unittest.mock.mock_open()):
+                q.put("test")
+            mock__queue.assert_called()
+
+    def test_putnowait(self):
+        q = iodict.DurableQueue(path="/not/a/path")
+        with patch.object(self.m, "_queue", autospec=True) as mock__queue:
+            mock__queue.return_value = dict()
+            with patch("builtins.open", unittest.mock.mock_open()):
+                q.put_nowait("test")
+            mock__queue.assert_called()
+
+
+class _FlushQueue(queue.Queue, iodict.FlushQueue):
+    def __init__(self, path, lock=None, semaphore=None):
+        super().__init__()
+        self.path = path
+        self.lock = lock
+        self.semaphore = semaphore
+
+
+class TestFlushQueue(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.patched_iodict = patch("directord.iodict.IODict", autospec=True)
+        self.mock_iodict = self.patched_iodict.start()
+        self.m = self.mock_iodict.return_value = MagicMock()
+        self.m._db_path = "/not/a/path"
+        self.patched_queue = patch.object(self.m, "_queue", autospec=True)
+        self.mock__queue = self.patched_queue.start()
+        self.mock__queue.return_value = dict()
+
+    def tearDown(self):
+        super().tearDown()
+        self.patched_iodict.stop()
+        self.patched_queue.stop()
+
+    @patch("os.scandir", autospec=True)
+    def test_flush_ingest(self, mock_scandir):
+        mock_scandir.return_value = [MockItem("file1"), MockItem("file2")]
+        q = _FlushQueue(path="/not/a/path")
+        for i in range(10):
+            q.put(i)
+
+        self.assertEqual(q.qsize(), 10)
+        with patch("builtins.open", unittest.mock.mock_open()):
+            q.flush()
+        self.assertEqual(q.qsize(), 0)
+        with patch("os.path.exists", autospec=True) as mock_exists:
+            mock_exists.return_value = True
+            with patch("os.rmdir", autospec=True) as mock_rmdir:
+                with patch("os.unlink", autospec=True):
+                    q.ingest()
+
+        mock_exists.assert_called()
+        mock_rmdir.assert_called()
+
+    def test_ingest_no_exists(self):
+        q = _FlushQueue(path="/not/a/path")
+        with patch("os.path.exists", autospec=True) as mock_exists:
+            mock_exists.return_value = False
+            q.ingest()
+        self.mock__queue.assert_not_called()
+
+    @patch("os.scandir", autospec=True)
+    def test_ingest(self, mock_scandir):
+        mock_scandir.return_value = [MockItem("file1"), MockItem("file2")]
+        q = _FlushQueue(path="/not/a/path")
+        with patch("os.path.exists", autospec=True) as mock_exists:
+            mock_exists.return_value = True
+            with patch("directord.iodict.DurableQueue") as mock_durablequeue:
+                m = mock_durablequeue.return_value = MagicMock()
+                g = m.get_nowait = MagicMock()
+                g.side_effect = ["a", KeyError]
+                with patch("os.unlink", autospec=True):
+                    q.ingest()
+        self.mock__queue.assert_not_called()
+
+    def test_flushqueue_attrs(self):
+        q = iodict.FlushQueue(path="/not/a/path")
+        self.assertEqual(q.path, "/not/a/path")
+        self.assertEqual(q.lock, None)
+        self.assertEqual(q.semaphore, None)

--- a/directord/tests/test_user.py
+++ b/directord/tests/test_user.py
@@ -156,7 +156,7 @@ class TestManager(tests.TestDriverBase):
         )
 
     @patch("builtins.print")
-    @patch("directord.utils.Cache", autospec=True)
+    @patch("directord.iodict.Cache", autospec=True)
     def test_run_override_dump_cache(self, mock_diskcache, mock_print):
         cache = mock_diskcache.return_value = tests.FakeCache()
         cache.setdefault(key="test", value="value")

--- a/directord/user.py
+++ b/directord/user.py
@@ -20,7 +20,7 @@ import time
 import directord
 
 from directord import interface
-from directord import utils
+from directord import iodict
 
 
 class User(interface.Interface):
@@ -297,7 +297,7 @@ class Manage(User):
 
         def _cache_dump():
             try:
-                cache = utils.Cache(
+                cache = iodict.Cache(
                     path=os.path.join(self.args.cache_path, "client")
                 )
                 print(json.dumps(dict(cache.items()), indent=4))

--- a/directord/utils.py
+++ b/directord/utils.py
@@ -21,7 +21,6 @@ import sys
 import time
 import uuid
 
-import iodict
 import tabulate
 import yaml
 
@@ -29,8 +28,8 @@ from ssh import options
 from ssh.session import Session
 from ssh import key as ssh_key
 
-from directord import logger
 from directord import components
+from directord import logger
 
 
 def dump_yaml(file_path, data):
@@ -366,34 +365,3 @@ def component_lock_search():
             pass
     else:
         return lock_commands
-
-
-class Cache(iodict.IODict):
-    """Helper class to create the Cache object."""
-
-    pass
-
-
-class BaseQueue:
-    def getter(self):
-        """Yield items from the queue until empty."""
-
-        while True:
-            try:
-                item = self.get_nowait()
-            except Exception:
-                break
-            else:
-                yield item
-
-
-class DurableQueue(BaseQueue, iodict.DurableQueue):
-    """Helper class to create the DurableQueue object."""
-
-    pass
-
-
-class FlushQueue(BaseQueue, iodict.FlushQueue):
-    """Helper class to cerate a flushing queue."""
-
-    pass

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setuptools.setup(
         "ssh-python",
         "tabulate",
         "tenacity",
-        "iodict",
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tools/prod-setup.sh
+++ b/tools/prod-setup.sh
@@ -64,8 +64,6 @@ if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]] || [[ ${ID} == "fedora" ]]; 
     wget https://github.com/directord/directord/releases/download/${RELEASE}/rpm-bundle.tar.gz
     tar xf rpm-bundle.tar.gz
     RPMS=$(ls -1 *.rpm | egrep -v '(debug|src)')
-    IODICTRELEASE="$(get_latest_release directord/iodict)"
-    dnf -y install ${RPMS} https://github.com/directord/directord/releases/download/${IODICTRELEASE}/iodict-${IODICTRELEASE}-1.el8.noarch.rpm
   popd
   echo -e "\nDirectord is setup and installed within [ /usr/bin ]"
   echo "Activate the venv or run directord directly."


### PR DESCRIPTION
iodict was a stand-alone dep, this change pulls that developed dep back
into the core code base so that we're not having to deal with and manage
separate packages.

Signed-off-by: Kevin Carter <kevin@cloudnull.com>