### PR TITLE
move signals to the process interface

### DIFF
--- a/directord/__init__.py
+++ b/directord/__init__.py
@@ -19,7 +19,6 @@ import multiprocessing
 import os
 import queue
 import socket
-import signal
 import sys
 
 from types import SimpleNamespace
@@ -149,13 +148,6 @@ class Processor:
         """Initialize Processor class."""
 
         self.log = logger.getLogger(name="directord")
-        signal.signal(signal.SIGINT, self.exit_gracefully)
-        signal.signal(signal.SIGTERM, self.exit_gracefully)
-
-    def exit_gracefully(self, *args, **kwargs):
-        """Handle a graceful exit of the application."""
-
-        raise SystemExit("Stop signal intercepted {}".format(args))
 
     @staticmethod
     def get_manager():

--- a/directord/client.py
+++ b/directord/client.py
@@ -25,7 +25,7 @@ from directord import iodict
 from directord import utils
 
 
-class Client(interface.Interface):
+class Client(interface.ProcessInterface):
     """Directord client class."""
 
     def __init__(self, args):

--- a/directord/interface.py
+++ b/directord/interface.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import signal
 
 import directord
 
@@ -87,3 +88,26 @@ class Interface(directord.Processor):
                         self.args.driver, str(e)
                     )
                 ) from None
+
+
+class ProcessInterface(Interface):
+    """The ProcessInterface class.
+
+    This class defines everything required to execute the application process.
+    """
+
+    def __init__(self, args):
+        """Initialize the process interface class.
+
+        :param args: Arguments parsed by argparse.
+        :type args: Object
+        """
+
+        super(ProcessInterface, self).__init__(args=args)
+        signal.signal(signal.SIGINT, self.exit_gracefully)
+        signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+    def exit_gracefully(self, *args, **kwargs):
+        """Handle a graceful exit of the application."""
+
+        raise SystemExit("Stop signal intercepted {}".format(args))

--- a/directord/server.py
+++ b/directord/server.py
@@ -27,7 +27,7 @@ from directord import models
 from directord import utils
 
 
-class Server(interface.Interface):
+class Server(interface.ProcessInterface):
     """Directord server class."""
 
     def __init__(self, args):


### PR DESCRIPTION
Signals can not be part of the client interface, otherwise they'll
create a conflict should the client class use multiprocessing.

Closes: #363
Signed-off-by: Kevin Carter <kevin@cloudnull.com>