### PR TITLE
Drop server side query timeout

### DIFF
--- a/directord/server.py
+++ b/directord/server.py
@@ -627,7 +627,6 @@ class Server(interface.ProcessInterface):
         :type job_id: String
         """
 
-        start_time = time.time()
         while True:
             if self.return_jobs[job_id].failed:
                 self.log.critical(
@@ -636,11 +635,6 @@ class Server(interface.ProcessInterface):
                 return
             elif all(self.return_jobs[job_id].STDOUT.values()):
                 break
-            elif start_time + 600 >= time.time():
-                self.log.error(
-                    "Query job [ %s ] encountered a timeout.", job_id
-                )
-                return
 
             self.log.info("Waiting for [ %s ], QUERY to complete", job_id)
             time.sleep(1)


### PR DESCRIPTION
This is causing query tasks to error out early because the query may
take a while on some nodes to start executing.  This likely needs to be
revisited to better handle query timeouts.