### PR TITLE
Use individual args for bootstrap interface

### DIFF
--- a/directord/main.py
+++ b/directord/main.py
@@ -715,7 +715,12 @@ def main():
             else:
                 return
     elif args.mode == "bootstrap":
-        _bootstrap = bootstrap.Bootstrap(args=args)
+        _bootstrap = bootstrap.Bootstrap(
+            args.catalog,
+            args.key_file,
+            args.threads,
+            args.debug,
+        )
         _bootstrap.bootstrap_cluster()
     else:
         parser.print_help(sys.stderr)

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -135,6 +135,9 @@ class FakeArgs:
     socket_group = "root"
     cache_path = "/var/cache/directord"
     backend_port = 5556
+    catalog = []
+    key_file = "~/.ssh/id_rsa"
+    threads = 10
     timeout = 600
     zmq_shared_key = None
     zmq_curve_encryption = None

--- a/directord/tests/test_bootstrap.py
+++ b/directord/tests/test_bootstrap.py
@@ -28,7 +28,12 @@ class Testbootstrap(tests.TestConnectionBase):
         self.args = tests.FakeArgs()
         self.patch_spinner = patch("directord.Spinner", autospec=True)
         self.patch_spinner.start()
-        self.bootstrap = bootstrap.Bootstrap(args=self.args)
+        self.bootstrap = bootstrap.Bootstrap(
+            catalog=self.args.catalog,
+            key_file=self.args.key_file,
+            threads=self.args.threads,
+            debug=self.args.debug,
+        )
         self.execute = ["long '{{ jinja }}' quoted string", "string"]
         self.orchestration = {
             "targets": [
@@ -302,8 +307,8 @@ class Testbootstrap(tests.TestConnectionBase):
     @patch("directord.bootstrap.Bootstrap.run_threads", autospec=True)
     def test_bootstrap_cluster(self, mock_threads):
         try:
-            setattr(self.args, "catalog", ["/file.yaml"])
-            setattr(self.args, "threads", 3)
+            self.bootstrap.catalog = ["/file.yaml"]
+            self.bootstrap.threads = 3
             m = unittest.mock.mock_open(read_data=tests.TEST_CATALOG.encode())
             with patch("builtins.open", m):
                 self.bootstrap.bootstrap_cluster()


### PR DESCRIPTION
Instead of using an argparse parser as the interface to the Bootstrap
class, use individual arguments instead. This makes the interface more
generically consumable from other tools (tripleoclient).

Signed-off-by: James Slagle <jslagle@redhat.com>
