### PR TITLE
Use sudo in rpm and config bootstrap

### DIFF
--- a/tools/directord-rpm-bootstrap-zmq.yaml
+++ b/tools/directord-rpm-bootstrap-zmq.yaml
@@ -2,12 +2,12 @@
 
 directord_server:
   jobs:
-  - RUN: dnf -y install https://www.rdoproject.org/repos/rdo-release.el8.rpm
-  - RUN: dnf -y copr enable slagle/tripleo centos-stream-8-x86_64
-  - RUN: dnf install -y directord python3-zmq python3-ssh-python
+  - RUN: sudo dnf -y install https://www.rdoproject.org/repos/rdo-release.el8.rpm
+  - RUN: sudo dnf -y copr enable slagle/tripleo centos-stream-8-x86_64
+  - RUN: sudo dnf install -y directord python3-zmq python3-ssh-python
 
 directord_clients:
   jobs:
-  - RUN: dnf -y install https://www.rdoproject.org/repos/rdo-release.el8.rpm
-  - RUN: dnf -y copr enable slagle/tripleo centos-stream-8-x86_64
-  - RUN: dnf install -y directord python3-zmq python3-ssh-python
+  - RUN: sudo dnf -y install https://www.rdoproject.org/repos/rdo-release.el8.rpm
+  - RUN: sudo dnf -y copr enable slagle/tripleo centos-stream-8-x86_64
+  - RUN: sudo dnf install -y directord python3-zmq python3-ssh-python


### PR DESCRIPTION
sudo is required in these RUN jobs as the ssh user may not be root.

Signed-off-by: James Slagle <jslagle@redhat.com>
