### PR TITLE
Add bootstraps to manage/unmanage the cluster

### DIFF
--- a/tools/directord-manage-bootstrap.yaml
+++ b/tools/directord-manage-bootstrap.yaml
@@ -1,0 +1,8 @@
+---
+directord_server:
+  jobs:
+  - RUN: sudo systemctl restart directord-server.service
+
+directord_clients:
+  jobs:
+  - RUN: sudo systemctl restart directord-client.service

--- a/tools/directord-unmanage-bootstrap.yaml
+++ b/tools/directord-unmanage-bootstrap.yaml
@@ -1,0 +1,8 @@
+---
+directord_server:
+  jobs:
+  - RUN: sudo systemctl stop directord-server.service
+
+directord_clients:
+  jobs:
+  - RUN: sudo systemctl stop directord-client.service


### PR DESCRIPTION
The manage and unmanage bootstraps are used to stop and start directord
services across the cluster.

Signed-off-by: James Slagle <jslagle@redhat.com>
