### PR TITLE
Allow drivers to run in isolation

### DIFF
--- a/.github/workflows/pull-request-facter.yml
+++ b/.github/workflows/pull-request-facter.yml
@@ -47,18 +47,20 @@ jobs:
                                               functional-tests-facter.yaml \
                                               --poll \
                                               --check
-
       - name: Generate log details
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: functional-facter-test-logs
-          path: /tmp/directord-*.log
+          name: functional-test-logs
+          path: /tmp/directord*

--- a/.github/workflows/pull-request-functional.yml
+++ b/.github/workflows/pull-request-functional.yml
@@ -229,7 +229,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
       - name: Run install
-        run: sudo bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
+        run: sudo EXTRA_DEPENDENCIES=redis bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
       - name: Install Redis
         run: sudo apt install -y redis
       - name: Start Redis

--- a/.github/workflows/pull-request-functional.yml
+++ b/.github/workflows/pull-request-functional.yml
@@ -38,16 +38,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_messaging_check:
     runs-on: ubuntu-latest
@@ -130,7 +133,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
       - name: Run install
-        run: sudo DRIVER=zmq bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
+        run: sudo DRIVER=zeromq bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
       - name: Run server service install
         run: |
           sudo /opt/directord/bin/directord-server-systemd
@@ -156,16 +159,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-zmq-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_posix_check:
     runs-on: ubuntu-latest
@@ -207,16 +213,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-posix-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_redis_check:
     runs-on: ubuntu-latest
@@ -262,16 +271,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-redis-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_defaults_query_check:
     runs-on: ubuntu-latest
@@ -310,16 +322,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-query-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_defaults_queuesentinel_check:
     runs-on: ubuntu-latest
@@ -357,16 +372,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-queuesentinel-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_defaults_async_check:
     runs-on: ubuntu-latest
@@ -421,16 +439,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-async-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_messaging_async_check:
     runs-on: ubuntu-latest
@@ -499,15 +520,14 @@ jobs:
                                              --check
       - name: Generate log details
         run: |
-          sudo mkdir -p /tmp/directord
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
-          sudo cp /etc/directord/messaging/ssl/directord* /tmp/directord
-          sudo cp /usr/local/share/ca-certificates/directord/* /tmp/directord
-          sudo cp /etc/qpid-dispatch/qdrouterd.* /tmp/directord
+          sudo cp -R /etc/directord /tmp/
+          sudo cp /usr/local/share/ca-certificates/directord/* /tmp/directord/
+          sudo cp /etc/qpid-dispatch/qdrouterd.* /tmp/directord/
           sudo find /tmp/directord -type d -exec chmod 0755 {} \;
           sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
@@ -529,7 +549,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
       - name: Run install
-        run: sudo DRIVER=zmq bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
+        run: sudo DRIVER=zeromq bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
       - name: Run server service install
         run: |
           sudo /opt/directord/bin/directord-server-systemd
@@ -571,16 +591,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-zmq-async-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_defaults_add_check:
     runs-on: ubuntu-latest
@@ -619,16 +642,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-add-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_bootstrap_check:
     runs-on: ubuntu-latest
@@ -698,7 +724,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: functional-bootstrap-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_defaults_realworld_check:
     runs-on: ubuntu-latest
@@ -737,16 +763,19 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-realworld-test-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*
 
   functional_prune_check:
     runs-on: ubuntu-latest
@@ -783,13 +812,16 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: functional-prune-logs
-          path: /tmp/directord-*.log
+          path: /tmp/directord*

--- a/.github/workflows/pull-request-podman.yml
+++ b/.github/workflows/pull-request-podman.yml
@@ -40,7 +40,6 @@ jobs:
           sudo podman build -t test-image .
           sudo podman system service --log-level debug -t 0 unix:///tmp/podman.sock &>/tmp/directord-podman-api.log &
           sudo podman run --rm --name registry -d -p 5000:5000 registry:2
-
       - name: Wait for client online
         run: |
           timeout 120 bash -c 'while ! sudo /opt/directord/bin/directord manage --list-nodes; do sleep 1; done'
@@ -52,21 +51,24 @@ jobs:
                                               functional-podman-test.yaml \
                                               --poll \
                                               --check
-
       - name: Generate log details
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: functional-podman-test-logs
-          path: /tmp/directord-*.log
+          name: functional-test-logs
+          path: /tmp/directord*
+
 
   functional_defaults_podman_pod_check:
     runs-on: ubuntu-latest
@@ -142,13 +144,16 @@ jobs:
         run: |
           sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
           sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
-          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
-          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
-          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
+          sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log || true
+          sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log || true
+          sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log || true
+          sudo cp -R /etc/directord /tmp/
+          sudo find /tmp/directord -type d -exec chmod 0755 {} \;
+          sudo find /tmp/directord -type f -exec chmod 0644 {} \;
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: functional-pod-test-logs
-          path: /tmp/directord-*.log
+          name: functional-test-logs
+          path: /tmp/directord*

--- a/.github/workflows/pull-request-podman.yml
+++ b/.github/workflows/pull-request-podman.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
       - name: Run install
-        run: sudo bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
+        run: sudo EXTRA_DEPENDENCIES=dev bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
       - name: Run server service install
         run: |
           sudo /opt/directord/bin/directord-server-systemd
@@ -79,7 +79,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
       - name: Run install
-        run: sudo bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
+        run: sudo EXTRA_DEPENDENCIES=dev bash tools/dev-setup.sh /opt/directord python3 ${{ github.workspace }}
       - name: Run server service install
         run: |
           sudo /opt/directord/bin/directord-server-systemd

--- a/Containerfile
+++ b/Containerfile
@@ -18,7 +18,7 @@ WORKDIR /build
 RUN python3.8 -m venv /build/builder
 RUN /build/builder/bin/pip install --force --upgrade pip setuptools bindep wheel
 ADD . /build/
-RUN bash -c "/build/tools/dev-setup.sh /directord /bin/python3.8 /build false"
+RUN bash -c "EXTRA_DEPENDENCIES=all /build/tools/dev-setup.sh /directord /bin/python3.8 /build false"
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 EXPOSE 5555

--- a/directord/components/builtin_service.py
+++ b/directord/components/builtin_service.py
@@ -93,7 +93,7 @@ class Component(components.ComponentBase):
             data["state"] = "disable"
         if self.known_args.mask:
             data["mask"] = "mask"
-        elif self.known_args.unamsk:
+        elif self.known_args.unmask:
             data["mask"] = "unmask"
 
         if self.known_args.restarted:

--- a/directord/drivers/dummy.py
+++ b/directord/drivers/dummy.py
@@ -14,6 +14,8 @@
 
 from directord import drivers
 
+DRIVER_AVAILABLE = True
+
 
 def parse_args(parser, parser_server, parser_client):
     """Add arguments for this driver to the parser.

--- a/directord/drivers/grpcd.py
+++ b/directord/drivers/grpcd.py
@@ -29,7 +29,10 @@ try:
     from directord.drivers.generated.msg_pb2_grpc import (
         MessageServiceServicer as grpc_MessageServiceServicer,
     )
+
+    DRIVER_AVAILABLE = True
 except (ImportError, ModuleNotFoundError):
+    DRIVER_AVAILABLE = False
     grpc_MessageServiceServicer = object
     pass
 

--- a/directord/drivers/messaging.py
+++ b/directord/drivers/messaging.py
@@ -26,7 +26,10 @@ try:
     from oslo_messaging.rpc import dispatcher
     from oslo_messaging.rpc.server import expose
     from oslo_messaging import transport
+
+    DRIVER_AVAILABLE = True
 except (ImportError, ModuleNotFoundError):
+    DRIVER_AVAILABLE = False
 
     def expose(*args, **kwargs):
         """Mock expose."""

--- a/directord/drivers/zeromq.py
+++ b/directord/drivers/zeromq.py
@@ -48,16 +48,16 @@ def parse_args(parser, parser_server, parser_client):
     :returns: Object
     """
 
-    group = parser.add_argument_group("ZMQ driver options")
+    group = parser.add_argument_group("ZeroMQ driver options")
     group.add_argument(
         "--zmq-highwater-mark",
         type=int,
-        default=os.getenv("DIRECTORD_ZMQ_HIGHWATER_MARK", 1024),
+        default=int(os.getenv("DIRECTORD_ZMQ_HIGHWATER_MARK", 1024)),
         metavar="INTEGER",
-        help=("Set the ZMQ highwater mark. Default %(default)s."),
+        help=("Set the ZeroMQ highwater mark. Default %(default)s."),
     )
     server_group = parser_server.add_argument_group(
-        "ZMQ Server driver options"
+        "ZeroMQ Server driver options"
     )
     server_group.add_argument(
         "--zmq-generate-keys",
@@ -67,19 +67,19 @@ def parse_args(parser, parser_server, parser_client):
     server_group.add_argument(
         "--zmq-bind-address",
         help=(
-            "ZMQ IP Address to bind a Directord Server."
+            "ZeroMQ IP Address to bind a Directord Server."
             " Default: %(default)s"
         ),
         metavar="STRING",
         default=os.getenv("DIRECTORD_ZMQ_BIND_ADDRESS", "*"),
     )
     client_group = parser_client.add_argument_group(
-        "ZMQ Client driver options"
+        "ZeroMQ Client driver options"
     )
     client_group.add_argument(
         "--zmq-server-address",
         help=(
-            "ZMQ Domain or IP address of the Directord server."
+            "ZeroMQ Domain or IP address of the Directord server."
             " Default: %(default)s"
         ),
         metavar="STRING",
@@ -98,7 +98,7 @@ def parse_args(parser, parser_server, parser_client):
         help=(
             "Server and client will connect using Curve authentication"
             " and encryption. Enabling this option assumes keys have been"
-            " generated. see `--zmq-generate-keys` for more."
+            " generated. see `--zmq-generate-keys` under `server` for more."
         ),
     )
 
@@ -381,16 +381,16 @@ class Driver(drivers.BaseDriver):
         registered with self.poller as defined within the Interface
         class.
 
-        :param socket_type: Set the Socket type, typically defined using a ZMQ
-                            constant.
+        :param socket_type: Set the Socket type, typically defined using a
+                            ZeroMQ constant.
         :type socket_type: Integer
         :param connection: Set the Address information used for the bound
                            socket.
         :type connection: String
         :param port: Define the port which the socket will be bound to.
         :type port: Integer
-        :param poller_type: Set the Socket type, typically defined using a ZMQ
-                            constant.
+        :param poller_type: Set the Socket type, typically defined using a
+                            ZeroMQ constant.
         :type poller_type: Integer
         :returns: Object
         """
@@ -466,16 +466,16 @@ class Driver(drivers.BaseDriver):
           before going into a retry loop. This is done to forcefully cycle
           the connection object to reset.
 
-        :param socket_type: Set the Socket type, typically defined using a ZMQ
-                            constant.
+        :param socket_type: Set the Socket type, typically defined using a
+                            ZeroMQ constant.
         :type socket_type: Integer
         :param connection: Set the Address information used for the bound
                            socket.
         :type connection: String
         :param port: Define the port which the socket will be bound to.
         :type port: Integer
-        :param poller_type: Set the Socket type, typically defined using a ZMQ
-                            constant.
+        :param poller_type: Set the Socket type, typically defined using a
+                            ZeroMQ constant.
         :type poller_type: Integer
         :returns: Object
         """
@@ -545,8 +545,8 @@ class Driver(drivers.BaseDriver):
     def _socket_context(self, socket_type):
         """Create socket context and return a bind object.
 
-        :param socket_type: Set the Socket type, typically defined using a ZMQ
-                            constant.
+        :param socket_type: Set the Socket type, typically defined using a
+                            ZeroMQ constant.
         :type socket_type: Integer
         :returns: Object
         """

--- a/directord/drivers/zmq.py
+++ b/directord/drivers/zmq.py
@@ -25,8 +25,10 @@ try:
     import zmq
     import zmq.auth as zmq_auth
     from zmq.auth.thread import ThreadAuthenticator
+
+    DRIVER_AVAILABLE = True
 except (ImportError, ModuleNotFoundError):
-    pass
+    DRIVER_AVAILABLE = False
 
 from directord import drivers
 from directord import iodict

--- a/directord/main.py
+++ b/directord/main.py
@@ -109,8 +109,10 @@ def _args(exec_args=None):
         "--config-file",
         help="File path for client configuration. Default: %(default)s",
         metavar="STRING",
-        default=os.getenv("DIRECTORD_CONFIG_FILE", None),
-        type=argparse.FileType(mode="r"),
+        default=os.getenv(
+            "DIRECTORD_CONFIG_FILE", "/etc/directord/config.yaml"
+        ),
+        type=str,
     )
     parser.add_argument(
         "--driver",
@@ -441,7 +443,8 @@ def _args(exec_args=None):
     else:
         args = parser.parse_args()
     # Check for configuration file and load it if found.
-    if args.config_file:
+    if os.path.isfile(args.config_file) or os.path.islink(args.config_file):
+        args.__dict__["config_file"] = open(args.__dict__["config_file"])
         config_data = yaml.safe_load(args.config_file)
         if config_data:
             for key, value in config_data.items():

--- a/directord/main.py
+++ b/directord/main.py
@@ -75,10 +75,17 @@ def _parse_driver_args(parser, parser_server, parser_client):
         driver = driver_importer.find_module(driver_name).load_module(
             driver_name
         )
-        if hasattr(driver, "parse_args"):
-            parser = driver.parse_args(parser, parser_server, parser_client)
 
-        sys.modules.pop(driver_name, None)
+        try:
+            if getattr(driver, "DRIVER_AVAILABLE", False) is False:
+                continue
+
+            if hasattr(driver, "parse_args"):
+                parser = driver.parse_args(
+                    parser, parser_server, parser_client
+                )
+        finally:
+            sys.modules.pop(driver_name, None)
 
     return parser
 

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -122,7 +122,7 @@ class FakeArgs:
     config_file = None
     datastore = None
     debug = False
-    driver = "zmq"
+    driver = "zeromq"
     dump_cache = False
     heartbeat_interval = 60
     job_port = 5555

--- a/directord/tests/test_drivers_zmq.py
+++ b/directord/tests/test_drivers_zmq.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 import zmq
 
 from directord import tests
-from directord.drivers import zmq as zmq_driver
+from directord.drivers import zeromq as zmq_driver
 
 
 class TestDriverZMQSharedAuth(tests.TestBase):
@@ -56,7 +56,7 @@ class TestDriverZMQSharedAuth(tests.TestBase):
 
     @patch("zmq.backend.Socket", autospec=True)
     @patch("zmq.Poller", autospec=True)
-    @patch("directord.drivers.zmq.ThreadAuthenticator", autospec=True)
+    @patch("directord.drivers.zeromq.ThreadAuthenticator", autospec=True)
     def test_socket_bind_shared_curve_auth(
         self, mock_auth, mock_poller, mock_socket
     ):
@@ -97,7 +97,7 @@ class TestDriverZMQ(tests.TestBase):
 
     @patch("zmq.backend.Socket", autospec=True)
     @patch("zmq.Poller", autospec=True)
-    @patch("directord.drivers.zmq.ThreadAuthenticator", autospec=True)
+    @patch("directord.drivers.zeromq.ThreadAuthenticator", autospec=True)
     def test_socket_bind_shared_auth(
         self, mock_auth, mock_poller, mock_socket
     ):
@@ -304,7 +304,7 @@ class TestDriverZMQ(tests.TestBase):
             flags=0,
         )
 
-    @patch("directord.drivers.zmq.Driver._socket_bind", autospec=True)
+    @patch("directord.drivers.zeromq.Driver._socket_bind", autospec=True)
     def test_job_bind(self, mock_socket_bind):
         self.driver._job_bind()
         mock_socket_bind.assert_called_with(
@@ -314,7 +314,7 @@ class TestDriverZMQ(tests.TestBase):
             port=5555,
         )
 
-    @patch("directord.drivers.zmq.Driver._socket_bind", autospec=True)
+    @patch("directord.drivers.zeromq.Driver._socket_bind", autospec=True)
     def test_backend_bind(self, mock_socket_bind):
         self.driver._backend_bind()
         mock_socket_bind.assert_called_with(
@@ -332,12 +332,12 @@ class TestDriverZMQ(tests.TestBase):
                 1000000180.0000001,
             )
 
-    @patch("directord.drivers.zmq.Driver._socket_connect", autospec=True)
+    @patch("directord.drivers.zeromq.Driver._socket_connect", autospec=True)
     def test_job_connect(self, mock_socket_connect):
         self.driver._job_connect()
         mock_socket_connect.assert_called()
 
-    @patch("directord.drivers.zmq.Driver._socket_connect", autospec=True)
+    @patch("directord.drivers.zeromq.Driver._socket_connect", autospec=True)
     def test_backend_connect(self, mock_socket_connect):
         self.driver._backend_connect()
         mock_socket_connect.assert_called()

--- a/directord/tests/test_main.py
+++ b/directord/tests/test_main.py
@@ -46,7 +46,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -76,7 +76,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -104,7 +104,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -132,7 +132,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -160,7 +160,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -188,7 +188,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -217,7 +217,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -245,7 +245,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -273,7 +273,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -301,7 +301,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "check": False,
                 "datastore": "memory",
                 "debug": False,
@@ -329,7 +329,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -349,7 +349,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -371,7 +371,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -403,7 +403,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -435,7 +435,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -467,7 +467,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -499,7 +499,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -531,7 +531,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -563,7 +563,7 @@ class TestMain(tests.TestBase):
         self.assertDictEqual(
             vars(args),
             {
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -598,7 +598,7 @@ class TestMain(tests.TestBase):
             vars(args),
             {
                 "catalog": mock.ANY,
-                "config_file": None,
+                "config_file": "/etc/directord/config.yaml",
                 "datastore": "memory",
                 "debug": False,
                 "driver": "grpcd",
@@ -707,7 +707,7 @@ class TestMain(tests.TestBase):
     @patch("directord.main._args", autospec=True)
     def test_main_server(self, mock__args):
         _args = {
-            "config_file": None,
+            "config_file": "/etc/directord/config.yaml",
             "zmq_shared_key": None,
             "zmq_curve_encryption": False,
             "debug": False,
@@ -730,7 +730,7 @@ class TestMain(tests.TestBase):
     @patch("directord.main._args", autospec=True)
     def test_main_client(self, mock__args, mock__client):
         _args = {
-            "config_file": None,
+            "config_file": "/etc/directord/config.yaml",
             "zmq_shared_key": None,
             "zmq_curve_encryption": False,
             "debug": False,
@@ -752,7 +752,7 @@ class TestMain(tests.TestBase):
     @patch("directord.main._args", autospec=True)
     def test_main_exec(self, mock__args):
         _args = {
-            "config_file": None,
+            "config_file": "/etc/directord/config.yaml",
             "zmq_shared_key": None,
             "zmq_curve_encryption": False,
             "debug": False,
@@ -779,7 +779,7 @@ class TestMain(tests.TestBase):
     @patch("directord.main._args", autospec=True)
     def test_main_orchestrate(self, mock__args):
         _args = {
-            "config_file": None,
+            "config_file": "/etc/directord/config.yaml",
             "zmq_shared_key": None,
             "zmq_curve_encryption": False,
             "debug": False,
@@ -808,7 +808,7 @@ class TestMain(tests.TestBase):
     @patch("directord.main._args", autospec=True)
     def test_main_manage(self, mock__args):
         _args = {
-            "config_file": None,
+            "config_file": "/etc/directord/config.yaml",
             "zmq_shared_key": None,
             "zmq_curve_encryption": False,
             "debug": False,
@@ -841,7 +841,7 @@ class TestMain(tests.TestBase):
     def test_main_bootstrap(self, mock__args):
         _args = {
             "catalog": mock.ANY,
-            "config_file": None,
+            "config_file": "/etc/directord/config.yaml",
             "zmq_shared_key": None,
             "zmq_curve_encryption": False,
             "debug": False,
@@ -868,7 +868,7 @@ class TestMain(tests.TestBase):
     def test_main_fail(self, mock__args):
         _args = {
             "catalog": mock.ANY,
-            "config_file": None,
+            "config_file": "/etc/directord/config.yaml",
             "zmq_shared_key": None,
             "zmq_curve_encryption": False,
             "debug": False,

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -64,8 +64,8 @@ as a point of correlation.
 
 | Service                 | Configuration    | Actual Runtime (Seconds) |
 | ----------------------- | ---------------- | ------------------------ |
-| Directord               | ZMQ Driver       | 19                       |
-| Directord (async)       | ZMQ Driver       | 15                       |
+| Directord               | ZeroMQ Driver       | 19                       |
+| Directord (async)       | ZeroMQ Driver       | 15                       |
 | Directord               | Messaging Driver | 101                      |
 | Directord (async)       | Messaging Driver | 99                       |
 | Directord               | GRPC Driver      |                          |

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -7,7 +7,7 @@ Directord is powered by message platforms. As such, to run Directord a
 messaging driver needs to be selected, which may require additional setup
 based on the operating environment.
 
-## ZMQ
+## ZeroMQ
 
 Status: `Stable`
 
@@ -19,7 +19,7 @@ No additional setup is required outside of the initial package installation.
 
 ![Directord](assets/driver-zmq.png)
 
-Directord with the ZMQ driver supports two forms of authentication, **Shared
+Directord with the ZeroMQ driver supports two forms of authentication, **Shared
 Key** and **Curve25519**. Both of these authentication methods enhance the
 security of an environment however both methods have some pros and cons.
 
@@ -55,7 +55,7 @@ $ directord --zmq-shared-key ${SECRET_TOKEN} client
 
 **Curve25519** is a more complicated method to setup as keys have to be
 generated and synchronized to all client and server nodes. While generating
-keys is simple with the `directord --driver zmq server --zmq-generate-keys` command,
+keys is simple with the `directord --driver zeromq server --zmq-generate-keys` command,
 the **Curve25519** method is called out as more complex due to the requirement
 of file transfers. **Curve25519** will encrypt the traffic within the cluster
 making it suitable for deployments that extend beyond a single data center.
@@ -70,7 +70,7 @@ The following command will generate the encryption keys required to enable
 **Curve25519**.
 
 ``` shell
-$ directord --driver zmq server --zmq-generate-keys
+$ directord --driver zeromq server --zmq-generate-keys
 ```
 
 > If the `--zmq-generate-keys` command is run more than once it will backup old key
@@ -117,7 +117,7 @@ run, which will first generate new keys on the server and run a simple
 orchestration to rotate the keys across an active cluster.
 
 ``` shell
-$ directord --driver zmq server --zmq-generate-keys
+$ directord --driver zeromq server --zmq-generate-keys
 $ directord orchestrate key-rotation.yaml
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,9 @@ REQUIREMENTS = {
     "redis": ["redis"],
     "oslo_messaging": ["oslo_messaging[amqp1]"],
     "zmq": ["pyzmq"],
-    "grpc": [GPRC_PACKAGE, "protobuf", "requests"],
+    "grpc": [GPRC_PACKAGE, "protobuf"],
 }
+
 REQUIREMENTS["all"] = list(
     set([item for line in REQUIREMENTS.values() for item in line])
 )
@@ -52,6 +53,7 @@ setuptools.setup(
     install_requires=[
         "jinja2",
         "pyyaml",
+        "requests",
         "ssh-python",
         "tabulate",
         "tenacity",

--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,19 @@ with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 
+GPRC_PACKAGE = "grpcio-tools<=1.26.0"
+
 REQUIREMENTS = {
-    "dev": ["podman-py", "grpcio-tools<=1.26.0"],
+    "dev": ["podman-py", GPRC_PACKAGE],
     "test": ["flake8", "coverage"],
     "redis": ["redis"],
     "oslo_messaging": ["oslo_messaging[amqp1]"],
     "zmq": ["pyzmq"],
-    "grpc": ["grpcio<=1.26.0", "protobuf"],
+    "grpc": [GPRC_PACKAGE, "protobuf", "requests"],
 }
-REQUIREMENTS["all"] = [item for line in REQUIREMENTS.values() for item in line]
+REQUIREMENTS["all"] = list(
+    set([item for line in REQUIREMENTS.values() for item in line])
+)
 
 
 setuptools.setup(

--- a/tools/ansible-bootstrap-playbook.yaml
+++ b/tools/ansible-bootstrap-playbook.yaml
@@ -43,7 +43,7 @@
     directord_bin_path: "{{ directord_development_env | bool | ternary('/opt/directord/bin', '/opt/directord/bin') }}"
   tasks:
     - name: Generate curve keys
-      command: "{{ directord_bin_path }}/directord --driver zmq server --zmq-generate-keys"
+      command: "{{ directord_bin_path }}/directord --driver zeromq server --zmq-generate-keys"
     - name: Specifying a destination path
       fetch:
         src: "{{ item }}"

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -49,7 +49,7 @@ if [[ ${ID} == "rhel" ]] && [[ ${DRIVER} == "messaging" ]]; then
     exit 1
 fi
 
-if [[ ${DRIVER} == "zmq" ]]; then
+if [[ ${DRIVER} == "zeromq" ]]; then
   export DEPENDENCIES="zmq"
 elif [[ ${DRIVER} == "messaging" ]]; then
   export DEPENDENCIES="oslo_messaging"
@@ -124,8 +124,8 @@ with open('/etc/directord/config.yaml', 'w') as f:
     f.write(yaml.safe_dump(config, default_flow_style=False))
 EOC
 
-if [ "${DRIVER}" == "zmq" ] && [ ! -f "/etc/directord/private_keys/server.key_secret" ]; then
-  ${VENV_PATH}/bin/directord --driver zmq server --zmq-generate-keys
+if [ "${DRIVER}" == "zeromq" ] && [ ! -f "/etc/directord/private_keys/server.key_secret" ]; then
+  ${VENV_PATH}/bin/directord --driver zeromq server --zmq-generate-keys
 fi
 
 if [ "${SETUP}" = true ]; then

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -19,6 +19,7 @@ PYTHON_BIN="${2:-${PYTHON_BIN:-python3.8}}"
 CLONE_PATH="${3:-${CLONE_PATH-}}"
 SETUP="${4:-${SETUP:-true}}"
 DRIVER=${DRIVER:-grpcd}
+EXTRA_DEPENDENCIES="${EXTRA_DEPENDENCIES:-}"
 
 . /etc/os-release
 
@@ -46,6 +47,20 @@ fi
 if [[ ${ID} == "rhel" ]] && [[ ${DRIVER} == "messaging" ]]; then
     echo "messaging driver not yet supported with RHEL."
     exit 1
+fi
+
+if [[ ${DRIVER} == "zmq" ]]; then
+  export DEPENDENCIES="zmq"
+elif [[ ${DRIVER} == "messaging" ]]; then
+  export DEPENDENCIES="oslo_messaging"
+elif [[ ${DRIVER} == "grpcd" ]]; then
+  export DEPENDENCIES="grpc"
+else
+  export DEPENDENCIES="all"
+fi
+
+if [[ ! -z "${EXTRA_DEPENDENCIES}" ]]; then
+  export DEPENDENCIES="${DEPENDENCIES},${EXTRA_DEPENDENCIES}"
 fi
 
 if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]]; then
@@ -86,9 +101,9 @@ ${VENV_PATH}/bin/pip install --upgrade pip setuptools wheel bindep pyyaml
 ${VENV_PATH}/bin/pip install --upgrade pip setuptools wheel
 
 if [ -z "${CLONE_PATH}" ] || [ ! -d "${CLONE_PATH}" ] ; then
-  ${VENV_PATH}/bin/pip install --upgrade --pre directord[all]
+  ${VENV_PATH}/bin/pip install --upgrade --pre directord[${DEPENDENCIES}]
 else
-  ${VENV_PATH}/bin/pip install --upgrade ${CLONE_PATH}[all]
+  ${VENV_PATH}/bin/pip install --upgrade ${CLONE_PATH}[${DEPENDENCIES}]
 fi
 
 # Create basic development configuration

--- a/tools/directord-config-bootstrap-zmq.yaml
+++ b/tools/directord-config-bootstrap-zmq.yaml
@@ -11,7 +11,7 @@ directord_server:
               config = yaml.safe_load(f)
       except FileNotFoundError:
           config = dict()
-      config['driver'] = "zmq"
+      config['driver'] = "zeromq"
       with open('/etc/directord/config.yaml', 'w') as f:
           f.write(yaml.safe_dump(config, default_flow_style=False))
       EOC

--- a/tools/directord-dev-bootstrap-zmq-encryption-catalog.yaml
+++ b/tools/directord-dev-bootstrap-zmq-encryption-catalog.yaml
@@ -3,7 +3,7 @@
 directord_server:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo bash dev-setup.sh
+  - RUN: sudo DRIVER=zmq bash dev-setup.sh
   - RUN: sudo /opt/directord/bin/directord-server-systemd
   - RUN: sudo systemctl daemon-reload
   - RUN: sudo systemctl enable directord-server.service
@@ -15,7 +15,7 @@ directord_server:
 directord_clients:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo bash dev-setup.sh
+  - RUN: sudo DRIVER=zmq bash dev-setup.sh
   - ADD: /tmp/client.key_secret /tmp/client.key_secret-stash
   - RUN: sudo mv /tmp/client.key_secret-stash /etc/directord/private_keys/client.key_secret
   - ADD: /tmp/client.key /tmp/client.key-stash

--- a/tools/directord-dev-bootstrap-zmq-encryption-catalog.yaml
+++ b/tools/directord-dev-bootstrap-zmq-encryption-catalog.yaml
@@ -3,7 +3,7 @@
 directord_server:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo DRIVER=zmq bash dev-setup.sh
+  - RUN: sudo DRIVER=zeromq bash dev-setup.sh
   - RUN: sudo /opt/directord/bin/directord-server-systemd
   - RUN: sudo systemctl daemon-reload
   - RUN: sudo systemctl enable directord-server.service
@@ -15,7 +15,7 @@ directord_server:
 directord_clients:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo DRIVER=zmq bash dev-setup.sh
+  - RUN: sudo DRIVER=zeromq bash dev-setup.sh
   - ADD: /tmp/client.key_secret /tmp/client.key_secret-stash
   - RUN: sudo mv /tmp/client.key_secret-stash /etc/directord/private_keys/client.key_secret
   - ADD: /tmp/client.key /tmp/client.key-stash

--- a/tools/directord-dev-bootstrap-zmq-no-server.yaml
+++ b/tools/directord-dev-bootstrap-zmq-no-server.yaml
@@ -2,7 +2,7 @@
 directord_clients:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo bash dev-setup.sh
+  - RUN: sudo DRIVER=zmq bash dev-setup.sh
   - RUN: sudo /opt/directord/bin/directord-client-systemd
   - RUN: |-
       sudo python3 <<EOC

--- a/tools/directord-dev-bootstrap-zmq-no-server.yaml
+++ b/tools/directord-dev-bootstrap-zmq-no-server.yaml
@@ -2,7 +2,7 @@
 directord_clients:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo DRIVER=zmq bash dev-setup.sh
+  - RUN: sudo DRIVER=zeromq bash dev-setup.sh
   - RUN: sudo /opt/directord/bin/directord-client-systemd
   - RUN: |-
       sudo python3 <<EOC

--- a/tools/directord-dev-bootstrap-zmq.yaml
+++ b/tools/directord-dev-bootstrap-zmq.yaml
@@ -3,7 +3,7 @@
 directord_server:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo bash dev-setup.sh
+  - RUN: sudo DRIVER=zmq bash dev-setup.sh
   - RUN: sudo /opt/directord/bin/directord-server-systemd
   - RUN: sudo systemctl daemon-reload
   - RUN: sudo systemctl enable directord-server.service
@@ -12,7 +12,7 @@ directord_server:
 directord_clients:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo bash dev-setup.sh
+  - RUN: sudo DRIVER=zmq bash dev-setup.sh
   - RUN: sudo /opt/directord/bin/directord-client-systemd
   - RUN: |-
       sudo python3 <<EOC

--- a/tools/directord-dev-bootstrap-zmq.yaml
+++ b/tools/directord-dev-bootstrap-zmq.yaml
@@ -3,7 +3,7 @@
 directord_server:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo DRIVER=zmq bash dev-setup.sh
+  - RUN: sudo DRIVER=zeromq bash dev-setup.sh
   - RUN: sudo /opt/directord/bin/directord-server-systemd
   - RUN: sudo systemctl daemon-reload
   - RUN: sudo systemctl enable directord-server.service
@@ -12,7 +12,7 @@ directord_server:
 directord_clients:
   jobs:
   - ADD: dev-setup.sh dev-setup.sh
-  - RUN: sudo DRIVER=zmq bash dev-setup.sh
+  - RUN: sudo DRIVER=zeromq bash dev-setup.sh
   - RUN: sudo /opt/directord/bin/directord-client-systemd
   - RUN: |-
       sudo python3 <<EOC

--- a/tools/directord-prod-bootstrap-zmq.yaml
+++ b/tools/directord-prod-bootstrap-zmq.yaml
@@ -15,7 +15,7 @@ directord_server:
               config = yaml.safe_load(f)
       except FileNotFoundError:
           config = dict()
-      config['driver'] = "zmq"
+      config['driver'] = "zeromq"
       with open('/etc/directord/config.yaml', 'w') as f:
           f.write(yaml.safe_dump(config, default_flow_style=False))
       EOC

--- a/tools/directord-restart-catalog.yaml
+++ b/tools/directord-restart-catalog.yaml
@@ -2,7 +2,7 @@
 
 directord_server:
   jobs:
-  - RUN: sudo /opt/directord/bin/directord --driver zmq server --zmq-generate-keys
+  - RUN: sudo /opt/directord/bin/directord --driver zeromq server --zmq-generate-keys
   - RUN: sudo systemctl restart directord-server.service
   - GET: /etc/directord/private_keys/client.key_secret /tmp/client.key_secret
   - GET: /etc/directord/public_keys/client.key /tmp/client.key

--- a/tools/prod-setup.sh
+++ b/tools/prod-setup.sh
@@ -15,6 +15,7 @@
 set -eo
 
 DRIVER=${DRIVER:-grpcd}
+EXTRA_DEPENDENCIES="${EXTRA_DEPENDENCIES:-}"
 
 if [[ $UID != 0 ]]; then
     echo "Please run this script with sudo:"
@@ -74,9 +75,21 @@ if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]] || [[ ${ID} == "fedora" ]]; 
     directord --driver zmq server --zmq-generate-keys
   fi
 else
+  if [[ ${DRIVER} == "zmq" ]]; then
+    export DEPENDENCIES="zmq"
+  elif [[ ${DRIVER} == "messaging" ]]; then
+    export DEPENDENCIES="oslo_messaging"
+  elif [[ ${DRIVER} == "grpcd" ]]; then
+    export DEPENDENCIES="grpc"
+  else
+    export DEPENDENCIES="all"
+  fi
+  if [[ ! -z "${EXTRA_DEPENDENCIES}" ]]; then
+    export DEPENDENCIES="${DEPENDENCIES},${EXTRA_DEPENDENCIES}"
+  fi
   python3 -m venv --system-site-packages /opt/directord
   /opt/directord/bin/pip install --upgrade pip setuptools wheel
-  /opt/directord/bin/pip install --upgrade directord[all]
+  /opt/directord/bin/pip install --upgrade directord[${DEPENDENCIES}]
 
   echo -e "\nDirectord is setup and installed within [ /opt/directord ]"
   echo "Activate the venv or run directord directly."

--- a/tools/prod-setup.sh
+++ b/tools/prod-setup.sh
@@ -72,10 +72,10 @@ if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]] || [[ ${ID} == "fedora" ]]; 
   echo "/usr/bin/directord-client-systemd"
   echo -e "/usr/bin/directord-server-systemd\n"
   if [ ! -f "/etc/directord/private_keys/server.key_secret" ]; then
-    directord --driver zmq server --zmq-generate-keys
+    directord --driver zeromq server --zmq-generate-keys
   fi
 else
-  if [[ ${DRIVER} == "zmq" ]]; then
+  if [[ ${DRIVER} == "zeromq" ]]; then
     export DEPENDENCIES="zmq"
   elif [[ ${DRIVER} == "messaging" ]]; then
     export DEPENDENCIES="oslo_messaging"
@@ -97,7 +97,7 @@ else
   echo "/opt/directord/bin/directord-client-systemd"
   echo -e "/opt/directord/bin/directord-server-systemd\n"
   if [ ! -f "/etc/directord/private_keys/server.key_secret" ]; then
-    /opt/directord/bin/directord --driver zmq server --zmq-generate-keys
+    /opt/directord/bin/directord --driver zeromq server --zmq-generate-keys
   fi
 fi
 


### PR DESCRIPTION
This change will allow each driver to run in isolation and ensure that
the options provided by the driver are only present in CLI interactions
when the driver would be functional. Non-functional drivers will be
omitted in the help output. This is a UX improvement, as well as a
packaging one.

Signed-off-by: Kevin Carter <kecarter@redhat.com>