### PR TITLE
Cmake dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ diagrams, installation, usage, and more can all be
 
 * When ready, if you'd like to contribute to Directord pull-requests are very
   welcomed. Directord is an open platform built for operators. If you see
-  something broken, please feel free to raise a but and/or fix it.
+  something broken, please feel free to raise a bug and/or fix it.
 
 * Information on running tests can be [found here](https://directord.com/testing).
 
 ### Have Questions?
 
 Join us on [`libera.chat`](https://libera.chat/guides/connect) at
-**#directord**. The community is just getting started: folks are here to help,
+**#directord**. The community is just getting started; folks are here to help,
 answer questions, and support one another.
 
 ## Quick Introduction

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -64,7 +64,7 @@ if [[ ! -z "${EXTRA_DEPENDENCIES}" ]]; then
 fi
 
 if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]]; then
-  PACKAGES="git gcc gcc-c++ python3-pyyaml zeromq libsodium"
+  PACKAGES="git gcc gcc-c++ python3-pyyaml zeromq libsodium cmake"
   if [[ ${DRIVER} == "messaging" ]]; then
     PACKAGES+=" qpid-dispatch-router certmonger openssl openssl-devel python3-devel"
   fi
@@ -78,7 +78,7 @@ if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]]; then
   dnf -y install ${PACKAGES}
   CA_PATH=/etc/pki/ca-trust/source/anchors/directord-ca.crt
 elif [[ ${ID} == "fedora" ]]; then
-  PACKAGES="git python3-devel gcc gcc-c++ python3-pyyaml zeromq libsodium qpid-dispatch-router certmonger openssl openssl-devel python3-devel"
+  PACKAGES="git python3-devel gcc gcc-c++ python3-pyyaml zeromq libsodium qpid-dispatch-router certmonger openssl openssl-devel python3-devel cmake"
   dnf -y install ${PACKAGES}
   PYTHON_BIN=${2:-python3}
   CA_PATH=/etc/pki/ca-trust/source/anchors/directord-ca.crt


### PR DESCRIPTION
Server and Clients require cmake to install ssh-python during the bootstrap process.