### PR TITLE
Handle if grpcio-tools isn't installed

### DIFF
--- a/directord/drivers/grpcd.py
+++ b/directord/drivers/grpcd.py
@@ -32,7 +32,7 @@ try:
             "directord/drivers/generated/msg.proto"
         )
         grpc_MessageServiceServicer = msg_pb2_grpc.MessageServiceServicer
-    except NotImplementedError:
+    except (AttributeError, NotImplementedError):
         # Fall back to our generated version which requires grpc <= 1.26.0
         from directord.drivers.generated import msg_pb2
         from directord.drivers.generated import msg_pb2_grpc


### PR DESCRIPTION
If grpcio-tools isn't available, you get an AttributeError instead of an
NotImplementedError.

Signed-off-by: Alex Schultz <aschultz@redhat.com>