### PR TITLE
Support "--job-info last"

### DIFF
--- a/directord/constants.py
+++ b/directord/constants.py
@@ -1,0 +1,16 @@
+#   Copyright 2022 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+# Job related constants
+JOB_LAST = "last"

--- a/directord/main.py
+++ b/directord/main.py
@@ -371,7 +371,10 @@ def _args(exec_args=None):
     )
     manage_group.add_argument(
         "--job-info",
-        help="Pull information on a specific job ID.",
+        help=(
+            "Pull information on a specific job ID.\n"
+            "Supports special identifiers (last)"
+        ),
         metavar="STRING",
     )
     manage_group.add_argument(

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -800,3 +800,7 @@ class TestServer(tests.TestDriverBase):
         mock_run_threads.assert_called_with(
             ANY, threads=[ANY, ANY, ANY], stop_event=ANY
         )
+
+    def test_handle_job_info(self):
+        data = self.server.handle_job_info("last")
+        self.assertEqual("XXX", dict(data)["last"]["job_id"])

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -489,6 +489,13 @@ ROUNDTRIP_TIME        0.023545026779174805
 Total Items: 14
 ```
 
+The `--job-info` command also accepts special identifiers (`last`), to more
+quickly inspect certain executions.
+
+``` shell
+$ directord --debug manage --job-info last
+```
+
 ###### Building an Orchestration
 
 ``` yaml


### PR DESCRIPTION
Adds support for the "last" special identifier with the --job-info
commands, which can be used to show the last (most recent) execution.

Signed-off-by: James Slagle <jslagle@redhat.com>
