### PR TITLE
Remove python3-ssh-python build and update packaging

### DIFF
--- a/contrib/container-build/Containerfile
+++ b/contrib/container-build/Containerfile
@@ -24,16 +24,6 @@ RUN dnf -y update && \
     chown -R builder /home/builder/build && \
     echo '%builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# TODO(cloudnull): remove all this when ssh-python is packaged
-RUN dnf -y install rpmdevtools python3-pytoml python3-pyxdg python38-requests cmake openssl openssl-devel python3-devel wget && \
-    dnf -y groupinstall 'Development Tools' && \
-    python3 -m venv /home/builder/pyp2rpm --system-site-packages && \
-    /home/builder/pyp2rpm/bin/pip install pyp2rpm && \
-    /home/builder/pyp2rpm/bin/pyp2rpm --srpm ssh-python -d /home/builder/rpm -b 3 && \
-    rpmbuild --rebuild "$(ls -1 /home/builder/rpm/python*-ssh-python*.src.rpm)"  --nodeps --nocheck && \
-    find ~/rpmbuild/RPMS -name '*.rpm' -exec cp "{}" /home/builder/build/ \; && \
-    dnf -y install $(find /home/builder/build/ -name '*rpm' ! -name '*src*' -type f)
-
 COPY directord.tar.gz /home/builder/build/
 RUN tar -O -xzf /home/builder/build/directord.tar.gz directord*/contrib/rpm/directord.spec > /home/builder/build/directord.spec
 COPY builder.sh /home/builder/

--- a/contrib/rpm/directord.spec
+++ b/contrib/rpm/directord.spec
@@ -24,10 +24,10 @@ BuildRequires:  python3-tabulate
 BuildRequires:  python3-tenacity
 BuildRequires:  python3-oslo-messaging
 BuildRequires:  systemd-rpm-macros
-BuildRequires:  python3-ssh-python
 
 Requires:       python3-jinja2
 Requires:       python3-pyyaml
+Requires:       python3-requests
 Requires:       python3-tabulate
 Requires:       python3-tenacity
 
@@ -91,7 +91,7 @@ true
 
 %package server
 Summary:        Server components for Directord
-Requires:       %{pypi_name}
+Requires:       %{pypi_name} = %{version}-%{release}
 
 %description server
 Server components for Directord, including the Systemd unit files
@@ -101,9 +101,18 @@ Server components for Directord, including the Systemd unit files
 %{_unitdir}/directord-server.service
 %{_datadir}/directord/systemd/directord-server.service
 
+%post server
+%systemd_post %{pypi_name}-server
+
+%preun server
+%systemd_preun %{pypi_name}-server
+
+%postun server
+%systemd_postun_with_restart %{pypi_name}-server
+
 %package client
 Summary:        Client components for Directord
-Requires:       %{pypi_name}
+Requires:       %{pypi_name} = %{version}-%{release}
 
 %description client
 Client components for Directord, including the Systemd unit files
@@ -113,10 +122,22 @@ Client components for Directord, including the Systemd unit files
 %{_unitdir}/directord-client.service
 %{_datadir}/directord/systemd/directord-client.service
 
+%post client
+%systemd_post %{pypi_name}-client
+
+%preun client
+%systemd_preun %{pypi_name}-client
+
+%postun client
+%systemd_postun_with_restart %{pypi_name}-client
+
 %changelog
+* Wed Jan 19 2022 James Slagle <jslagle@redhat.com>
+- Packaging updates to align with Fedora/RDO review guidelines
+- Remove python3-ssh-python from BuildRequires
+
 * Mon Jan 8 2022 James Slagle <jslagle@redhat.com>
 - Packaging updates to align with Fedora/RDO review guidelines
 
 * Thu Jul 29 2021 Kevin Carter <kecarter@redhat.com>
 - Initial package.
-

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -31,7 +31,7 @@ if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]]; then
   if [[ ${ID} == "rhel" ]]; then
     dnf install -y python3 ${TRIPLEO_REPOS}
     DISTRO="--no-stream --distro rhel${VERSION_INFO[0]}"
-    tripleo-repos ${DISTRO} -b master current-tripleo ceph
+    tripleo-repos ${DISTRO} -b master current-tripleo
   elif [[ ${ID} == "centos" ]]; then
     dnf install -y python3 ${TRIPLEO_REPOS}
     DISTRO="--distro centos${VERSION_INFO[0]}"
@@ -45,7 +45,7 @@ if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]]; then
         curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos9-master/current-tripleo/delorean.repo
         curl -o /etc/yum.repos.d/delorean-deps.repo https://trunk.rdoproject.org/centos9-master/delorean-deps.repo
     else
-        tripleo-repos ${DISTRO} -b master current-tripleo ceph
+        tripleo-repos ${DISTRO} -b master current-tripleo
     fi
   fi
 fi


### PR DESCRIPTION
It's no longer necessary to build python3-ssh-python as it's now
packaged in RDO. It's also not a BuildRequires.

Signed-off-by: James Slagle <jslagle@redhat.com>
